### PR TITLE
Add new expr and alter Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,18 +28,21 @@ LOGIC_FILES=\
     lib intro formulas prop fol skolem fol_ex\
 
 TOP_FILES=\
-    expr utils parser lexer\
-    conn_ops\
+	expr expr2 conversion utils parser lexer\
+	conn_ops\
 	rule_preprocess stratification derivation \
 	bottom_up evaluation\
 	ast2fol ast2sql ast2ros\
 	ast2theorem \
 	bx\
-	debugger \
+	debugger\
+
+TOP_FILES_WITH_MLI=\
+	parser expr2 conversion\
 
 FILES=\
     $(LOGIC_FILES:%=logic/%)\
-    $(TOP_FILES)
+    $(TOP_FILES) \
 	
 .PHONY: all release clean depend #annot
 all: $(BIN_DIR)/$(EX_NAME)
@@ -57,26 +60,22 @@ $(OBJ_DIR)/$(MAIN_FILE).cmo: $(FILES:%=$(OBJ_DIR)/%.cmo) $(SOURCE_DIR)/$(MAIN_FI
 #Special rules for creating the lexer and parser
 $(SOURCE_DIR)/parser.ml $(SOURCE_DIR)/parser.mli: $(SOURCE_DIR)/parser.mly
 	ocamlyacc $<
-$(OBJ_DIR)/parser.cmi:	$(SOURCE_DIR)/parser.mli
-	$(DIR_GUARD)
-	ocamlc $(OCAMLC_FLAGS) -o $(OBJ_DIR)/parser -c $<
-$(OBJ_DIR)/parser.cmo:	$(SOURCE_DIR)/parser.ml $(OBJ_DIR)/parser.cmi
-	$(DIR_GUARD)
-	ocamlc $(OCAMLC_FLAGS) -o $(OBJ_DIR)/parser -c $<
 $(SOURCE_DIR)/lexer.ml:	$(SOURCE_DIR)/lexer.mll
 	ocamllex $<
+
+#With mli files.
+$(TOP_FILES_WITH_MLI:%=$(OBJ_DIR)/%.cmi): $(OBJ_DIR)/%.cmi: $(SOURCE_DIR)/%.mli
+	$(DIR_GUARD)
+	ocamlfind ocamlc $(OCAMLC_FLAGS) -o $(OBJ_DIR)/$* -c $<
+
+$(TOP_FILES_WITH_MLI:%=$(OBJ_DIR)/%.cmo): $(OBJ_DIR)/%.cmo: $(SOURCE_DIR)/%.ml $(OBJ_DIR)/%.cmi
+	$(DIR_GUARD)
+	ocamlfind ocamlc $(OCAMLC_FLAGS) -package $(PACKAGES) -thread -o $(OBJ_DIR)/$* -c $<
 
 #General rule for compiling
 $(OBJ_DIR)/%.cmi $(OBJ_DIR)/%.cmo $(OBJ_DIR)/%.cmt: $(SOURCE_DIR)/%.ml
 	$(DIR_GUARD)
 	ocamlfind ocamlc $(OCAMLC_FLAGS) -package $(PACKAGES) -thread -o $(OBJ_DIR)/$* -c $<
-
-# annot: $(FILES:%=$(SOURCE_DIR)/%.cmt) $(MAIN_FILE:%=$(SOURCE_DIR)/%.cmt)
-
-# $(FILES:%=$(SOURCE_DIR)/%.cmt) $(MAIN_FILE:%=$(SOURCE_DIR)/%.cmt): $(LOGIC_FILES:%=$(LOGIC_OBJ_DIR)/%.cmt) $(TOP_FILES:%=$(OBJ_DIR)/%.cmt) $(MAIN_FILE:%=$(OBJ_DIR)/%.cmt)
-# 	cp $(LOGIC_FILES:%=$(LOGIC_OBJ_DIR)/%.cmt) $(LOGIC_SOURCE_DIR)/
-# 	cp $(TOP_FILES:%=$(OBJ_DIR)/%.cmt) $(SOURCE_DIR)/
-# 	cp $(MAIN_FILE:%=$(OBJ_DIR)/%.cmt) $(SOURCE_DIR)/
 
 include depend
 
@@ -102,10 +101,23 @@ $(RELEASE_DIR)/$(MAIN_FILE).cmx: $(FILES:%=$(RELEASE_DIR)/%.cmx) $(SOURCE_DIR)/$
 #Special rules for creating the lexer and parser
 $(RELEASE_DIR)/parser.cmi:	$(SOURCE_DIR)/parser.mli
 	$(DIR_GUARD)
-	ocamlopt $(OCAMLOPT_FLAGS) -o $(RELEASE_DIR)/parser -c $<
+	ocamlfind ocamlopt $(OCAMLOPT_FLAGS) -o $(RELEASE_DIR)/parser -c $<
 $(RELEASE_DIR)/parser.cmx:	$(SOURCE_DIR)/parser.ml $(RELEASE_DIR)/parser.cmi
 	$(DIR_GUARD)
-	ocamlopt $(OCAMLOPT_FLAGS) -o $(RELEASE_DIR)/parser -c $<
+	ocamlfind ocamlopt $(OCAMLOPT_FLAGS) -o $(RELEASE_DIR)/parser -c $<
+
+#With mli files.
+$(TOP_FILES_WITH_MLI:%=$(RELEASE_DIR)/%.cmi): $(RELEASE_DIR)/%.cmi: $(SOURCE_DIR)/%.mli
+	$(DIR_GUARD)
+	ocamlfind ocamlopt $(OCAMLOPT_FLAGS) -o $(RELEASE_DIR)/$* -c $<
+
+$(TOP_FILES_WITH_MLI:%=$(RELEASE_DIR)/%.cmo): $(RELEASE_DIR)/%.cmo: $(SOURCE_DIR)/%.ml $(RELEASE_DIR)/%.cmi
+	$(DIR_GUARD)
+	ocamlfind ocamlopt $(OCAMLOPT_FLAGS) -package $(PACKAGES) -thread -o $(RELEASE_DIR)/$* -c $<
+
+$(TOP_FILES_WITH_MLI:%=$(RELEASE_DIR)/%.cmx): $(RELEASE_DIR)/%.cmx: $(SOURCE_DIR)/%.ml $(RELEASE_DIR)/%.cmi
+	$(DIR_GUARD)
+	ocamlfind ocamlopt $(OCAMLOPT_FLAGS) -package $(PACKAGES) -thread -o $(RELEASE_DIR)/$* -c $<
 
 #General rule for compiling
 $(RELEASE_DIR)/%.cmi $(RELEASE_DIR)/%.cmx: $(SOURCE_DIR)/%.ml

--- a/src/conversion.ml
+++ b/src/conversion.ml
@@ -1,0 +1,138 @@
+let const_of_const2 = function
+  | Expr2.Int num -> Expr.Int num
+  | Expr2.Real num -> Expr.Real num
+  | Expr2.String str -> Expr.String str
+  | Expr2.Bool bool -> Expr.Bool bool
+  | Expr2.Null -> Expr.Null
+
+let var_of_var2 = function
+  | Expr2.NamedVar str -> Expr.NamedVar str
+  | Expr2.NumberedVar num -> Expr.NumberedVar num
+  | Expr2.ConstVar const -> Expr.ConstVar (const_of_const2 const)
+  | Expr2.AnonVar -> Expr.AnonVar
+  | Expr2.AggVar (str1, str2) -> Expr.AggVar (str1, str2)
+
+let rec vterm_of_vterm2 = function
+  | Expr2.Const const -> Expr.Const (const_of_const2 const)
+  | Expr2.Var var -> Expr.Var (var_of_var2 var)
+  | Expr2.BinaryOp (op, lhs, rhs) ->
+    let lhs = vterm_of_vterm2 lhs in
+    let rhs = vterm_of_vterm2 rhs in
+    begin match op with
+      | "+" -> Expr.Sum (lhs, rhs)
+      | "-" -> Expr.Diff (lhs, rhs)
+      | "*" -> Expr.Times (lhs, rhs)
+      | "/" -> Expr.Div (lhs, rhs)
+      | "^" -> Expr.Concat (lhs, rhs)
+      | _ -> invalid_arg ("Undefined operator: " ^ op)
+    end
+  | Expr2.UnaryOp (op, arg) ->
+    let arg = vterm_of_vterm2 arg in
+    begin match op with
+      | "-" -> Expr.Neg arg
+      | _ -> invalid_arg ("Undefined operator: " ^ op)
+    end
+
+let rterm_of_rterm2 = function
+  | Expr2.Pred (str, vars) -> Expr.Pred (str, List.map var_of_var2 vars)
+  | Expr2.Deltainsert (str, vars) -> Expr.Deltainsert (str, List.map var_of_var2 vars)
+  | Expr2.Deltadelete (str, vars) -> Expr.Deltadelete (str, List.map var_of_var2 vars)
+
+let rec term_of_term2 = function
+  | Expr2.Rel rterm -> Expr.Rel (rterm_of_rterm2 rterm)
+  | Expr2.Not rterm -> Expr.Not (rterm_of_rterm2 rterm)
+  | Expr2.Equat eterm ->
+    begin match eterm with
+      | Expr2.Equation ("=", lhs, rhs) -> Expr.Equal (vterm_of_vterm2 lhs, vterm_of_vterm2 rhs)
+      | Expr2.Equation (op, lhs, rhs) -> Expr.Ineq (op, vterm_of_vterm2 lhs, vterm_of_vterm2 rhs)
+    end
+  | Expr2.Noneq eterm -> Expr.negate_eq @@ term_of_term2 (Equat eterm)
+
+let stype_of_stype2 = function
+  | Expr2.Sint -> Expr.Sint
+  | Expr2.Sreal -> Expr.Sreal
+  | Expr2.Sstring -> Expr.Sstring
+  | Expr2.Sbool -> Expr.Sbool
+
+let expr_of_expr2 Expr2.{ rules; facts; query; sources; view; constraints; primary_keys; } =
+  Expr.Prog (List.flatten [
+    List.map (fun (rterm, terms) -> Expr.Rule (rterm_of_rterm2 rterm, List.map term_of_term2 terms)) rules;
+    List.map (fun rterm -> Expr.Fact (rterm_of_rterm2 rterm)) facts;
+    (match query with Some rterm -> [Expr.Query (rterm_of_rterm2 rterm)] | None -> []);
+    List.map (fun (str, stypes) -> Expr.Source (str, List.map (fun (str, stype) -> (str, stype_of_stype2 stype)) stypes)) sources;
+    (match view with Some (str, stypes) -> [Expr.View (str, List.map (fun (str, stype) -> (str, stype_of_stype2 stype)) stypes)] | None -> []);
+    List.map (fun (rterm, terms) -> Expr.Constraint (rterm_of_rterm2 rterm, List.map term_of_term2 terms)) constraints;
+    List.map (fun (str, strs) -> Expr.Pk (str, strs)) primary_keys
+  ])
+
+let conj_query_of_conj_query2 = function
+  | Expr2.Conj_query (vars, rterms1, rterms2) ->
+    Expr.Conj_query (
+      List.map var_of_var2 vars,
+      List.map rterm_of_rterm2 rterms1,
+      List.map rterm_of_rterm2 rterms2
+    )
+
+let const2_of_const = function
+  | Expr.Int num -> Expr2.Int num
+  | Expr.Real num -> Expr2.Real num
+  | Expr.String str -> Expr2.String str
+  | Expr.Bool bool -> Expr2.Bool bool
+  | Expr.Null -> Expr2.Null
+
+let var2_of_var = function
+  | Expr.NamedVar str -> Expr2.NamedVar str
+  | Expr.NumberedVar num -> Expr2.NumberedVar num
+  | Expr.ConstVar const -> Expr2.ConstVar (const2_of_const const)
+  | Expr.AnonVar -> Expr2.AnonVar
+  | Expr.AggVar (str1, str2) -> Expr2.AggVar (str1, str2)
+
+let rec vterm2_of_vterm = function
+  | Expr.Const const -> Expr2.Const (const2_of_const const)
+  | Expr.Var var -> Expr2.Var (var2_of_var var)
+  | Expr.Sum (lhs, rhs) -> Expr2.BinaryOp ("=", vterm2_of_vterm rhs, vterm2_of_vterm rhs)
+  | Expr.Diff (lhs, rhs) -> Expr2.BinaryOp ("-", vterm2_of_vterm rhs, vterm2_of_vterm rhs)
+  | Expr.Times (lhs, rhs) -> Expr2.BinaryOp ("*", vterm2_of_vterm rhs, vterm2_of_vterm rhs)
+  | Expr.Div (lhs, rhs) -> Expr2.BinaryOp ("/", vterm2_of_vterm rhs, vterm2_of_vterm rhs)
+  | Expr.Concat (lhs, rhs) -> Expr2.BinaryOp ("^", vterm2_of_vterm rhs, vterm2_of_vterm rhs)
+  | Expr.Neg arg ->  Expr2.UnaryOp ("-", vterm2_of_vterm arg)
+  | BoolAnd _ -> invalid_arg "BoolAnd operation is not acceptable in Expr2"
+  | BoolOr _ -> invalid_arg "BoolOr operation is not acceptable in Expr2"
+  | BoolNot _ -> invalid_arg "BoolNot operation is not acceptable in Expr2"
+
+let rterm2_of_rterm = function
+  | Expr.Pred (str, vars) -> Expr2.Pred (str, List.map var2_of_var vars)
+  | Expr.Deltainsert (str, vars) -> Expr2.Deltainsert (str, List.map var2_of_var vars)
+  | Expr.Deltadelete (str, vars) -> Expr2.Deltadelete (str, List.map var2_of_var vars)
+
+let term2_of_term = function
+  | Expr.Rel rterm -> Expr2.Rel (rterm2_of_rterm rterm)
+  | Expr.Equal (lhs, rhs) -> Expr2.Equat (Expr2.Equation ("=", vterm2_of_vterm lhs, vterm2_of_vterm rhs))
+  | Expr.Ineq (op, lhs, rhs) -> Expr2.Equat (Expr2.Equation (op, vterm2_of_vterm lhs, vterm2_of_vterm rhs))
+  | Expr.Not rterm -> Expr2.Not (rterm2_of_rterm rterm)
+
+let stype2_of_stype = function
+  | Expr.Sint -> Expr2.Sint
+  | Expr.Sreal -> Expr2.Sreal
+  | Expr.Sstring -> Expr2.Sstring
+  | Expr.Sbool -> Expr2.Sbool
+
+let expr2_of_expr = function
+  | Expr.Prog stts ->
+    let stt2_of_stt = function
+      | Expr.Rule (rterm, terms) -> Expr2.Stt_Rule (rterm2_of_rterm rterm, List.map term2_of_term terms)
+      | Expr.Fact rterm -> Expr2.Stt_Fact (rterm2_of_rterm rterm)
+      | Expr.Query rterm -> Expr2.Stt_Query (rterm2_of_rterm rterm)
+      | Expr.Source (str, stypes) -> Expr2.Stt_Source (str, List.map (fun (str, stype) -> (str, stype2_of_stype stype)) stypes)
+      | Expr.View (str, stypes) -> Expr2.Stt_View (str, List.map (fun (str, stype) -> (str, stype2_of_stype stype)) stypes)
+      | Expr.Constraint (rterm, terms) -> Expr2.Stt_Constraint (rterm2_of_rterm rterm, List.map term2_of_term terms)
+      | Expr.Pk (str, strs) -> Expr2.Stt_Pk (str, strs) in
+    List.fold_left (fun expr stt -> Expr2.add_stt (stt2_of_stt stt) expr) Expr2.get_empty_expr stts
+
+let conj_query2_of_conj_query = function
+  | Expr.Conj_query (vars, rterms1, rterms2) ->
+    Expr2.Conj_query (
+      List.map var2_of_var vars,
+      List.map rterm2_of_rterm rterms1,
+      List.map rterm2_of_rterm rterms2
+    )

--- a/src/conversion.mli
+++ b/src/conversion.mli
@@ -1,0 +1,31 @@
+val const_of_const2: Expr2.const -> Expr.const
+
+val var_of_var2: Expr2.var -> Expr.var
+
+val vterm_of_vterm2: Expr2.vterm -> Expr.vterm
+
+val rterm_of_rterm2: Expr2.rterm -> Expr.rterm
+
+val term_of_term2: Expr2.term -> Expr.term
+
+val stype_of_stype2: Expr2.stype -> Expr.stype
+
+val expr_of_expr2: Expr2.expr -> Expr.expr
+
+val conj_query_of_conj_query2: Expr2.conj_query -> Expr.conj_query
+
+val const2_of_const: Expr.const -> Expr2.const
+
+val var2_of_var: Expr.var -> Expr2.var
+
+val vterm2_of_vterm: Expr.vterm -> Expr2.vterm
+
+val rterm2_of_rterm: Expr.rterm -> Expr2.rterm
+
+val term2_of_term: Expr.term -> Expr2.term
+
+val stype2_of_stype: Expr.stype -> Expr2.stype
+
+val expr2_of_expr: Expr.expr -> Expr2.expr
+
+val conj_query2_of_conj_query: Expr.conj_query -> Expr2.conj_query

--- a/src/evaluation.ml
+++ b/src/evaluation.ml
@@ -104,6 +104,7 @@ let eval (log:bool) explain_lst prog =
   let add_goal p =
     let lexbuf = Lexing.from_string p in
     let rterm = Parser.parse_rterm Lexer.token lexbuf in
+    let rterm = Conversion.rterm_of_rterm2 rterm in
     let rterm = Bottom_up.literal_of_rterm false rterm in
     goals := rterm :: !goals in
  
@@ -111,6 +112,7 @@ let eval (log:bool) explain_lst prog =
   let add_explain p =
     let lexbuf = Lexing.from_string p in
     let rterm = Parser.parse_rterm Lexer.token lexbuf in
+    let rterm = Conversion.rterm_of_rterm2 rterm in
     let rterm = Bottom_up.literal_of_rterm false rterm in
     explains := rterm :: !explains in
 
@@ -119,6 +121,7 @@ let eval (log:bool) explain_lst prog =
     try
       let lexbuf = Lexing.from_string q_str in
       let ast = Parser.parse_query Lexer.token lexbuf in
+      let ast = Conversion.conj_query_of_conj_query2 ast in
       let q = Bottom_up.query_of_ast ast in
       queries := q :: !queries
     with Parsing.Parse_error ->

--- a/src/expr2.ml
+++ b/src/expr2.ml
@@ -1,0 +1,103 @@
+type const =
+  | Int of int
+  | Real of float
+  | String of string
+  | Bool of bool 
+  | Null
+
+type var = 
+  | NamedVar of string 
+  | NumberedVar of int (* this is not used in parser *)
+  | ConstVar of const (* var in a literal in allowed to be a const like int or string, for example p(X,1) or p(X, 'tran') *)
+  | AnonVar (* anonimous variable *)
+  | AggVar of string * string (* the first string is function, the second is variable *)
+
+type vterm = (* value term *)
+  | Const of const
+  | Var of var
+  (* arithmetic expression *)
+  | BinaryOp of string * vterm * vterm (* string is one of '+', '-', '*', '/', '^' *)
+  | UnaryOp of string * vterm (* string is one of '-' *)
+
+type eterm = (* equation *)
+  | Equation of string * vterm * vterm (* string is one of '=', '<>', '<', '>', '<=', '>=' *)
+
+type rterm = (* rterm is literal *)
+  | Pred of string * var list (* string is name of predicate, var list is a list of variables *)
+  | Deltainsert of string * var list (* delta predicate for insertion *)
+  | Deltadelete of string * var list (* delta predicate for deletion *)
+
+type term = (* term is one of predicate (positive or negative), equation, non-equation *)
+  | Rel of rterm (* positive predicate *)
+  | Not of rterm (* negative predicate *)
+  | Equat of eterm  (* for example x = 5 *)
+  | Noneq of eterm (* for example NOT x = 5 *)
+
+type stype = (* data type in schema *)
+  | Sint
+  | Sreal
+  | Sstring
+  | Sbool
+
+type rule = rterm * term list
+
+type fact = rterm
+
+type query = rterm
+
+type source = string * (string * stype) list
+
+type view = string * (string * stype) list
+
+type constraint' = rterm * term list
+
+type primary_key = string * string list
+
+type expr = {
+  rules: rule list;
+  facts: fact list;
+  query: query option;
+  sources: source list;
+  view: view option;
+  constraints: constraint' list;
+  primary_keys: primary_key list;
+}
+
+type conj_query =
+  | Conj_query of var list * rterm list * rterm list
+
+let get_empty_pred = Pred ("⊥", [])
+
+let get_empty_expr = {
+  rules= [];
+  facts= [];
+  query= None;
+  sources= [];
+  view= None;
+  constraints= [];
+  primary_keys= [];
+}
+
+type stt =
+  | Stt_Rule of rule
+  | Stt_Fact of fact
+  | Stt_Query of query
+  | Stt_Source of source (* the predicate of edb relation which is Source relation want to update *)
+  | Stt_View of view
+  | Stt_Constraint of constraint'
+  | Stt_Pk of primary_key (* primary key *)
+
+let add_stt stt expr = match stt with
+  | Stt_Rule rule -> { expr with rules= rule :: expr.rules }
+  | Stt_Fact fact -> { expr with facts= fact :: expr.facts }
+  | Stt_Query query -> begin match expr.query with
+      | Some _ -> invalid_arg "Query should appear at most once"
+      | None -> { expr with query= Some query }
+    end
+  | Stt_Source source -> { expr with sources= source :: expr.sources }
+  | Stt_View view -> begin match expr.view with
+      | Some _ -> invalid_arg "View should appear at most once"
+      | None -> { expr with view= Some view }
+    end
+  | Stt_Constraint constraint' -> { expr with constraints= constraint' :: expr.constraints }
+  | Stt_Pk primary_key -> { expr with primary_keys= primary_key :: expr.primary_keys }

--- a/src/expr2.mli
+++ b/src/expr2.mli
@@ -1,0 +1,82 @@
+type const =
+  | Int of int
+  | Real of float
+  | String of string
+  | Bool of bool 
+  | Null
+
+type var = 
+  | NamedVar of string 
+  | NumberedVar of int (* this is not used in parser *)
+  | ConstVar of const (* var in a literal in allowed to be a const like int or string, for example p(X,1) or p(X, 'tran') *)
+  | AnonVar (* anonimous variable *)
+  | AggVar of string * string (* the first string is function, the second is variable *)
+
+type vterm = (* value term *)
+  | Const of const
+  | Var of var
+  (* arithmetic expression *)
+  | BinaryOp of string * vterm * vterm (* string is one of '+', '-', '*', '/', '^' *)
+  | UnaryOp of string * vterm (* string is one of '-' *)
+
+type eterm = (* equation *)
+  | Equation of string * vterm * vterm (* string is one of '=', '<>', '<', '>', '<=', '>=' *)
+
+type rterm = (* rterm is literal *)
+  | Pred of string * var list (* string is name of predicate, var list is a list of variables *)
+  | Deltainsert of string * var list (* delta predicate for insertion *)
+  | Deltadelete of string * var list (* delta predicate for deletion *)
+
+type term = (* term is one of predicate (positive or negative), equation, non-equation *)
+  | Rel of rterm (* positive predicate *)
+  | Not of rterm (* negative predicate *)
+  | Equat of eterm  (* for example x = 5 *)
+  | Noneq of eterm (* for example NOT x = 5 *)
+
+type stype = (* data type in schema *)
+  | Sint
+  | Sreal
+  | Sstring
+  | Sbool
+
+type rule = rterm * term list
+
+type fact = rterm
+
+type query = rterm
+
+type source = string * (string * stype) list
+
+type view = string * (string * stype) list
+
+type constraint' = rterm * term list
+
+type primary_key = string * string list
+
+type expr = {
+  rules: rule list;
+  facts: fact list;
+  query: query option;
+  sources: source list;
+  view: view option;
+  constraints: constraint' list;
+  primary_keys: primary_key list;
+}
+
+type conj_query =
+  | Conj_query of var list * rterm list * rterm list
+
+val get_empty_pred: rterm
+
+val get_empty_expr: expr
+
+type stt =
+  | Stt_Rule of rule
+  | Stt_Fact of fact
+  | Stt_Query of query
+  | Stt_Source of source (* the predicate of edb relation which is Source relation want to update *)
+  | Stt_View of view
+  | Stt_Constraint of constraint'
+  | Stt_Pk of primary_key (* primary key *)
+
+val add_stt: stt -> expr -> expr

--- a/src/main.ml
+++ b/src/main.ml
@@ -113,7 +113,7 @@ let print_conn_info conn =
 ;;
 
 let main () =
-  if (!print_version) then ((print_endline "BIRDS version 0.0.4"); exit 0);
+  if (!print_version) then ((print_endline "BIRDS version 0.0.5"); exit 0);
   if (!importschema) then 
     (if !log then print_endline "importing schema from the database"; 
     let c = new connection ~conninfo () in
@@ -140,7 +140,8 @@ let main () =
   (* add information of the file name to lexbuf *)
   lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname =  (if !inputf = "" then "stdin" else !inputf)};
   (* while true do *)
-  let original_ast = Parser.main Lexer.token lexbuf in 
+  let new_ast = Parser.main Lexer.token lexbuf in 
+  let original_ast = Conversion.expr_of_expr2 new_ast in 
   let shell_script = if !inputshell = "" then "#!/bin/sh\necho \"true\"" else (String.concat "\n" @@ read_file (!inputshell)) in
   let ast =  original_ast in
   let edb = extract_edb ast in 
@@ -368,7 +369,8 @@ let test() =
     lexbuf.lex_curr_p <- { lexbuf.lex_curr_p with pos_fname =  (if  inputf = "" then "stdin" else  inputf)};
     (* while true do *)
     try
-      let ast1 = Parser.main Lexer.token lexbuf in 
+      let new_ast = Parser.main Lexer.token lexbuf in 
+      let ast1 = Conversion.expr_of_expr2 new_ast in
       let ast = (constraint2rule ast1) in
       (* let edb = import_dbschema c ( dbschema) in  *)
       let edb = extract_edb ast in 

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -1,21 +1,20 @@
 %{ (* OCaml preamble *)
 
-  open Expr ;;
+  open Expr2 ;;
   open Utils ;;
   (* let parse_error (s : string) = spec_parse_error s 1;; *)
   (* end preamble *)
  %}
-  
+
 
 /* tokens declaration */
 
-%token <int> INT            /* token with int value    */
-%token <float> FLOAT            /* token with float value    */
-%token <string> STRING            /* token with string value    */
-%token <string> RELNAME       /* token with string value */
-%token <string> VARNAME         /* token with string value */
+%token <int> INT        /* token with int value    */
+%token <float> FLOAT    /* token with float value  */
+%token <string> STRING  /* token with string value */
+%token <string> RELNAME /* token with string value */
+%token <string> VARNAME /* token with string value */
 
-  
 %token QMARK SMARK VMARK DOT IMPLIEDBY PK
 %token TYPING SINT SREAL SSTRING SBOOL
 %token AND NOT OR TT FF BOT TOP
@@ -27,252 +26,262 @@
 %token EOP
 %token EOF
 %token ANONVAR /* anonymous variable */
-%token ANON   /* fake token to stop the grammar in the fact rule */
+%token ANON    /* fake token to stop the grammar in the fact rule */
 
 /* associativity and precedence when needed */
 %nonassoc IMPLIEDBY
 
 
-%start main               /*  entry point    */
-%type <Expr.expr> main
+%start main               /* entry point */
+%type <Expr2.expr> main
 
 %start parse_rterm
-%type <Expr.rterm> parse_rterm
+%type <Expr2.rterm> parse_rterm
 
 %start parse_query
-%type <Expr.conj_query> parse_query
+%type <Expr2.conj_query> parse_query
 
 %%
 
 /* Grammar */
-  main:	EOF	        { Prog [] }
-  | program  EOF                        { Prog (List.rev $1)  }
-  | error             { spec_parse_error "invalid syntax for a main program" 1; }
+  main:
+  | EOF         { get_empty_expr }
+  | program EOF { $1 }
+  | error       { spec_parse_error "invalid syntax for a main program" 1; }
   ;
 
   parse_rterm:
-  | predicate EOF     {$1}
-  | error             { spec_parse_error "invalid syntax for a rterm" 1; }
+  | predicate EOF { $1 }
+  | error         { spec_parse_error "invalid syntax for a rterm" 1; }
   ;
 
   parse_query:
-  | conj_query EOF     {$1}
-  | error             { spec_parse_error "invalid syntax for a conj_query" 1; }
+  | conj_query EOF { $1 }
+  | error          { spec_parse_error "invalid syntax for a conj_query" 1; }
   ;
   
   program: 
-  exprlist								{ $1 }
-  | error             { spec_parse_error "invalid syntax for a program" 1; }
+  | exprlist { $1 }
+  | error    { spec_parse_error "invalid syntax for a program" 1; }
   ;
 
   exprlist:
-  | expr								{ $1 :: []  }
-  | exprlist expr 						{ $2 :: $1 }
-  | error             { spec_parse_error "invalid syntax for a list of rules" 1; }
+  | expr          { add_stt $1 get_empty_expr }
+  | exprlist expr { add_stt $2 $1 }
+  | error         { spec_parse_error "invalid syntax for a list of rules" 1; }
   ;
 
   expr: 
-  | primary_key              { $1 }
-  | integrity_constraint              { $1 }
-  | rule	                            { $1 }
-  | query	                            { $1 }
-  | source	                            { $1 }
-  | view	                            { $1 }
-  | fact				    { $1 }
-  | error             { spec_parse_error "invalid syntax for a rule or a declaration of query/source/view/constraint" 1; }
-  ;
-  
-  fact:
-  predicate DOT                              {Fact $1 }
-  | error             { spec_parse_error "invalid syntax for a fact" 1; }
+  | primary_key          { Stt_Pk (fst $1, snd $1) }
+  | integrity_constraint { Stt_Constraint (fst $1, snd $1) }
+  | rule                 { Stt_Rule (fst $1, snd $1) }
+  | source               { Stt_Source (fst $1, snd $1) }
+  | view                 { Stt_View (fst $1, snd $1) }
+  | fact                 { Stt_Fact $1 }
+  | query                { Stt_Query $1 }
+  | error                { spec_parse_error "invalid syntax for a rule or a declaration of query/source/view/constraint" 1; }
   ;
 
   primary_key:
-  | PK LPAREN RELNAME SEP LBRACKET attrlist RBRACKET RPAREN	DOT	{ Pk ($3, $6) }
-  | PK LPAREN RELNAME SEP LBRACKET attrlist RBRACKET RPAREN EOF					{ spec_parse_error "miss a dot for a primary key" 3; }
-  | error             { spec_parse_error "invalid syntax for a primary key" 1; }
-  ;
-
-  attrlist: /* empty */					{ [] }
-  | STRING				    				{ String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)) :: [] }
-  | STRING SEP attrlist 					{ String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)) :: $3 } /* \!/ rec. on the right */
-  | error             { spec_parse_error "invalid syntax for a list of attributes" 1; }
+  | PK LPAREN RELNAME SEP LBRACKET attrlist RBRACKET RPAREN	DOT	{ ($3, $6) }
+  | PK LPAREN RELNAME SEP LBRACKET attrlist RBRACKET RPAREN EOF { spec_parse_error "miss a dot for a primary key" 3; }
+  | error                                                       { spec_parse_error "invalid syntax for a primary key" 1; }
   ;
 
   integrity_constraint:
-  | BOT IMPLIEDBY body DOT					{ Constraint ( get_empty_pred, $3) } 
-  | BOT LPAREN RPAREN IMPLIEDBY body DOT					{ Constraint ( Pred ("⊥", []), $5) }
-  | BOT IMPLIEDBY body EOF					{ spec_parse_error "miss a dot for a constraint" 3; }
-  | error             { spec_parse_error "invalid syntax for a constraint" 1; }
+  | BOT IMPLIEDBY body DOT               { (get_empty_pred, $3) } 
+  | BOT LPAREN RPAREN IMPLIEDBY body DOT { (Pred ("⊥", []), $5) }
+  | BOT IMPLIEDBY body EOF               { spec_parse_error "miss a dot for a constraint" 3; }
+  | error                                { spec_parse_error "invalid syntax for a constraint" 1; }
   ;
 
   rule:
-  head IMPLIEDBY body DOT				{ Rule ($1,$3) }
-  | head IMPLIEDBY body EOF  { spec_parse_error "miss a dot for a rule" 4; }
-  | error             { spec_parse_error "invalid syntax for a rule" 1; }
-  ; 
+  | head IMPLIEDBY body DOT { ($1, $3) }
+  | head IMPLIEDBY body EOF { spec_parse_error "miss a dot for a rule" 4; }
+  | error                   { spec_parse_error "invalid syntax for a rule" 1; }
+  ;
+
+  source:
+  | SMARK schema DOT { $2 } 
+  | SMARK schema EOF { spec_parse_error "miss a dot for a source relation" 3; }
+  | error            { spec_parse_error "invalid syntax for a source relation" 1; }
+  ;
+
+  view:
+  | VMARK schema DOT { $2 } 
+  | VMARK schema EOF { spec_parse_error "miss a dot for a view relation" 3; }
+  | error            { spec_parse_error "invalid syntax for a view relation" 1; }
+  ;
+  
+  fact:
+  | predicate DOT { $1 }
+  | error         { spec_parse_error "invalid syntax for a fact" 1; }
+  ;
+
+  query:
+  | QMARK predicate DOT { $2 } 
+  | QMARK predicate EOF { spec_parse_error "miss a dot for a query" 3; }
+  | error               { spec_parse_error "invalid syntax for a query" 1; }
+  ;
+
+  attrlist:
+  | /* empty */         { [] }
+  | STRING              { String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)) :: [] }
+  | STRING SEP attrlist { String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)) :: $3 } /* \!/ rec. on the right */
+  | error               { spec_parse_error "invalid syntax for a list of attributes" 1; }
+  ;
 
   head:
-  predicate						{ $1 }
-  | error             { spec_parse_error "invalid syntax for a head" 1; }
+  | predicate { $1 }
+  | error     { spec_parse_error "invalid syntax for a head" 1; }
   ;
 
   conj_query:
   | LPAREN varlist RPAREN IMPLIEDBY signed_literals 
     {
       let pos_literals, neg_literal = $5 in
-      Expr.Conj_query ($2, pos_literals, neg_literal)
+      Expr2.Conj_query ($2, pos_literals, neg_literal)
     }
-  | error             { spec_parse_error "invalid syntax for a conjunctive query" 1; }
+  | error { spec_parse_error "invalid syntax for a conjunctive query" 1; }
   ;
 
   signed_literals:
-  | predicate SEP signed_literals
-    { let pos, neg = $3 in $1 :: pos, neg }
-  | NOT predicate SEP signed_literals
-    { let pos, neg = $4 in pos, $2 :: neg }
-  | predicate { [$1], [] }
-  | NOT predicate { [], [$2] }
-  | error             { spec_parse_error "invalid syntax for a signed_literals" 1; }
+  | predicate SEP signed_literals     { let pos, neg = $3 in $1 :: pos, neg }
+  | NOT predicate SEP signed_literals { let pos, neg = $4 in pos, $2 :: neg }
+  | predicate                         { [$1], [] }
+  | NOT predicate                     { [], [$2] }
+  | error                             { spec_parse_error "invalid syntax for a signed_literals" 1; }
   ;
 
   body:
-  litlist						{ List.rev $1 }
-  | error             { spec_parse_error "invalid syntax for a body" 1; }
-  ;
-
-  query:
-  | QMARK predicate DOT					{ Query $2 } 
-  | QMARK predicate EOF					{ spec_parse_error "miss a dot for a query" 3; }
-  | error             { spec_parse_error "invalid syntax for a query" 1; }
-  ;
-
-  source:
-  | SMARK schema DOT					{ Source (fst $2, snd $2) } 
-  | SMARK schema EOF             { spec_parse_error "miss a dot for a source relation" 3; }
-  | error             { spec_parse_error "invalid syntax for a source relation" 1; }
-  ;
-
-  view:
-  | VMARK schema DOT					{ View (fst $2, snd $2) } 
-  | VMARK schema EOF             { spec_parse_error "miss a dot for a view relation" 3; }
-  | error             { spec_parse_error "invalid syntax for a view relation" 1; }
+  | litlist { List.rev $1 }
+  | error   { spec_parse_error "invalid syntax for a body" 1; }
   ;
 
   schema:
-  | RELNAME LPAREN attrtypelist RPAREN		{ ($1, $3) }
-  | error             { spec_parse_error "invalid syntax for a predicate" 1; }
+  | RELNAME LPAREN attrtypelist RPAREN { ($1, $3) }
+  | error                              { spec_parse_error "invalid syntax for a predicate" 1; }
   ;
 
-  attrtypelist: /* empty */					{ [] }
-  | STRING TYPING stype { (String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)), $3) :: [] }
-  | STRING TYPING stype SEP attrtypelist 					{ (String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)), $3) :: $5 } /* \!/ rec. on the right */
-  | error             { spec_parse_error "invalid syntax for a list of pairs of an attribute and its type" 1; }
+  attrtypelist:
+  | /* empty */                          { [] }
+  | STRING TYPING stype                  { (String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)), $3) :: [] }
+  | STRING TYPING stype SEP attrtypelist { (String.uppercase_ascii (String.sub $1 1 (String.length $1 - 2)), $3) :: $5 } /* \!/ rec. on the right */
+  | error                                { spec_parse_error "invalid syntax for a list of pairs of an attribute and its type" 1; }
   ;
 
   stype:
-  | SINT { Sint }
-  | SREAL { Sreal }
+  | SINT    { Sint }
+  | SREAL   { Sreal }
   | SSTRING { Sstring }
-  | SBOOL { Sbool }
+  | SBOOL   { Sbool }
+  ;
 
-  litlist: /* empty */					{ [] }
-  | literal						{ $1 :: [] }
-  | litlist AND literal					{ $3 :: $1 }
-  | litlist SEP literal				        { $3 :: $1 }
-  | error             { spec_parse_error "invalid syntax for a conjunction of literals" 1; }
+  litlist:
+  | /* empty */         { [] }
+  | literal             { $1 :: [] }
+  | litlist AND literal { $3 :: $1 }
+  | litlist SEP literal { $3 :: $1 }
+  | error               { spec_parse_error "invalid syntax for a conjunction of literals" 1; }
   ;
 
   literal:
-  | predicate							{ Rel $1 }
-  | NOT predicate 						{ Not $2 }
-  | equation							{ $1 }
-  | NOT equation					        { negate_eq $2 }
-  | error             { spec_parse_error "invalid syntax for a literal" 1; }
+  | predicate     { Rel $1 }
+  | NOT predicate { Not $2 }
+  | equation      { Equat $1 }
+  | NOT equation  { Noneq $2 }
+  | error         { spec_parse_error "invalid syntax for a literal" 1; }
   ;
 
   predicate:
-  | RELNAME LPAREN varlist RPAREN		{ Pred ($1, $3) }
-  | PLUS RELNAME LPAREN varlist RPAREN		{ Deltainsert ($2, $4) }
-  | MINUS RELNAME LPAREN varlist RPAREN		{ Deltadelete ($2, $4) }
-  | error             { spec_parse_error "invalid syntax for a predicate" 1; }
+  | RELNAME LPAREN varlist RPAREN       { Pred ($1, $3) }
+  | PLUS RELNAME LPAREN varlist RPAREN  { Deltainsert ($2, $4) }
+  | MINUS RELNAME LPAREN varlist RPAREN { Deltadelete ($2, $4) }
+  | error                               { spec_parse_error "invalid syntax for a predicate" 1; }
   ;
 
   equation:	
-  | value_expression EQ value_expression	{ Equal ($1, $3) }
-  | value_expression NE value_expression	{ Ineq ("<>", $1, $3) }
-  | value_expression LT value_expression	{ Ineq ( "<", $1, $3) }
-  | value_expression GT value_expression	{ Ineq ( ">", $1, $3) }
-  | value_expression LE value_expression	{ Ineq ("<=", $1, $3) }
-  | value_expression GE value_expression	{ Ineq (">=", $1, $3) }
-  | error             { spec_parse_error "invalid syntax for a comparison" 1; }
+  | value_expression EQ value_expression { Equation ( "=", $1, $3) }
+  | value_expression NE value_expression { Equation ("<>", $1, $3) }
+  | value_expression LT value_expression { Equation ( "<", $1, $3) }
+  | value_expression GT value_expression { Equation ( ">", $1, $3) }
+  | value_expression LE value_expression { Equation ("<=", $1, $3) }
+  | value_expression GE value_expression { Equation (">=", $1, $3) }
+  | error                                { spec_parse_error "invalid syntax for a comparison" 1; }
   ;
 
   value_expression:
-  | term {$1}
-  | value_expression PLUS term {Sum ($1, $3)}
-  | value_expression CONCAT term {Concat ($1, $3)}
-  | value_expression MINUS term {Diff ($1, $3)}
-  | error             { spec_parse_error "invalid syntax for a arithmetic expression" 1; }
+  | term                         { $1 }
+  | value_expression PLUS term   { BinaryOp ("+", $1, $3) }
+  | value_expression CONCAT term { BinaryOp ("^", $1, $3) }
+  | value_expression MINUS term  { BinaryOp ("-", $1, $3) }
+  | error                        { spec_parse_error "invalid syntax for a arithmetic expression" 1; }
+  ;
 
   term:
-  | factor {$1}
-  | term TIMES factor {Times ($1, $3)}
-  | term DIVIDE factor {Div ($1, $3)}
-  | error             { spec_parse_error "invalid syntax for a term" 1; }
+  | factor             { $1 }
+  | term TIMES factor  { BinaryOp ("*", $1, $3) }
+  | term DIVIDE factor { BinaryOp ("/", $1, $3) }
+  | error              { spec_parse_error "invalid syntax for a term" 1; }
+  ;
 
   factor:
-  | value_primary {$1}
-  | error             { spec_parse_error "invalid syntax for a factor" 1; }
+  | value_primary { $1 }
+  | error         { spec_parse_error "invalid syntax for a factor" 1; }
+  ;
 
   value_primary:
-  | parenthesized_value_expression {$1}
-  | MINUS parenthesized_value_expression {Neg $2}
-  | nonparenthesized_value_primary {$1}
-  | error             { spec_parse_error "invalid syntax for a primary number" 1; }
+  | parenthesized_value_expression       { $1 }
+  | MINUS parenthesized_value_expression { UnaryOp ("-", $2) }
+  | nonparenthesized_value_primary       { $1 }
+  | error                                { spec_parse_error "invalid syntax for a primary number" 1; }
+  ;
 
   nonparenthesized_value_primary:
-  | constant {Const $1}
-  | var_or_agg {Var $1}
-  | error             { spec_parse_error "invalid syntax for a primar number" 1; }
+  | constant   { Const $1 }
+  | var_or_agg { Var $1 }
+  | error      { spec_parse_error "invalid syntax for a primar number" 1; }
+  ;
 
   parenthesized_value_expression:
-  | LPAREN value_expression RPAREN {$2}
-  | error             { spec_parse_error "invalid syntax for a parenthesized expression" 1; }
+  | LPAREN value_expression RPAREN { $2 }
+  | error                          { spec_parse_error "invalid syntax for a parenthesized expression" 1; }
+  ;
 
   var_or_agg:
-  | VARNAME     { NamedVar $1 }
-  | aggregate   { $1 }
-  | error             { spec_parse_error "invalid syntax for a var or a aggreation" 1; }
+  | VARNAME   { NamedVar $1 }
+  | aggregate { $1 }
+  | error     { spec_parse_error "invalid syntax for a var or a aggreation" 1; }
   ;
 
   constant:
-  | INT               {Int $1}
-  | MINUS INT               {Int (- $2)}
-  | FLOAT               {Real $1}
-  | MINUS FLOAT               {Real (-. $2)}
-  | STRING            {String $1}
-  | NULL            {Null}
-  | FF             {Bool false}
-  | TT             {Bool true}
-  | error             { spec_parse_error "invalid syntax for a constant" 1; }
+  | INT         { Int $1 }
+  | MINUS INT   { Int (- $2) }
+  | FLOAT       { Real $1 }
+  | MINUS FLOAT { Real (-. $2) }
+  | STRING      { String $1 }
+  | NULL        { Null }
+  | FF          { Bool false }
+  | TT          { Bool true }
+  | error       { spec_parse_error "invalid syntax for a constant" 1; }
   ;
 
-  varlist: /* empty */					{ [] }
-  | var				    				{ $1 :: [] }
-  | var SEP varlist 					{ $1 :: $3 } /* \!/ rec. on the right */
-  | error             { spec_parse_error "invalid syntax for a list of variables" 1; }
+  varlist:
+  | /* empty */     { [] }
+  | var             { $1 :: [] }
+  | var SEP varlist { $1 :: $3 } /* \!/ rec. on the right */
+  | error           { spec_parse_error "invalid syntax for a list of variables" 1; }
   ;
 
   var:
-  | VARNAME     { NamedVar $1 }
-  | ANONVAR     { AnonVar }
-  | constant    { ConstVar $1 }
-  | aggregate    { $1 }
-  | error             { spec_parse_error "invalid syntax for a variables" 1; }
+  | VARNAME   { NamedVar $1 }
+  | ANONVAR   { AnonVar }
+  | constant  { ConstVar $1 }
+  | aggregate { $1 }
+  | error     { spec_parse_error "invalid syntax for a variables" 1; }
   ;
 
   aggregate:
-  | VARNAME LPAREN VARNAME RPAREN       { AggVar ($1,$3) }
-  | error             { spec_parse_error "invalid syntax for a aggregation" 1; }
+  | VARNAME LPAREN VARNAME RPAREN { AggVar ($1,$3) }
+  | error                         { spec_parse_error "invalid syntax for a aggregation" 1; }
   ;


### PR DESCRIPTION
### Description

In this PR we are doing the following work

### Introduction of the new syntax tree definition

The existing syntax tree was unnecessarily recursive in its definitions and was implemented inappropriately for the BIRDS' syntax definition. This has been improved and a new syntax tree data type has been introduced which is more faithful to the syntax definition and more readable.

A function was provided to convert from the new syntax tree to the old one, in order to achieve a gradual migration without destroying the behaviour of the existing code. All analysis of the source code is still done in the new syntax tree at this stage, but it is converted from there to the old syntax tree and then processed as before.

### Introduction of mli files

OCaml basically used mli files to clarify typedefs and hide unwanted implementations, but they were not used in this source code until now. We now have a proper mli file for the new syntax tree file.

#### TODO

- [x] Remove old parser/lexer files.
- [x] Alter evaluation.ml.
- [x] Run benchmarks.