### PR TITLE
To output safe datalog

### DIFF
--- a/src/test/sql2ast_test.ml
+++ b/src/test/sql2ast_test.ml
@@ -117,7 +117,7 @@ let main () =
        *   -t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6) :- t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6), GenV2 = 'v2', GenV3 = 'v100', GenV1 <> 'v1'.
        *   -t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6) :- t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6), GenV2 = 'v2', GenV3 = 'v100', GenV3 <> 'v3'.
        *   -t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6) :- t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6), GenV2 = 'v2', GenV3 = 'v100', GenV5 <> 'v5'.
-       *   +t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6) :- GenV1 = v1, GenV3 = v3, GenV5 = v5, -t(GenV1_2, GenV2, GenV3_2, GenV4, GenV5_2, GenV6).
+       *   +t(GenV1, GenV2, GenV3, GenV4, GenV5, GenV6) :- GenV1 = 'v1', GenV3 = 'v3', GenV5 = 'v5', -t(GenV1_2, GenV2, GenV3_2, GenV4, GenV5_2, GenV6).
        *
        *)
       input = (


### PR DESCRIPTION
## 解説
https://github.com/proof-ninja/BIRDS/pull/19 で追加した新機能の修正です。
修正要求は以下の通り。

### 出力される Datalog 式について

```
PR94のSql2ast.update_to_datalogは、与えられたSQLのUPDATEをDatalog式に変換している。
しかしながら、この変換では安全なDatalog式になっていない。
[安全なDatalog式とは]
Datalogは論理型言語であり評価結果がinfiniteになってしまう場合がある。
このようなDatalogのことをunsafeと呼ぶ。
評価結果がfiniteなることを保証しているDatalogのことを安全な(safe)Datalogと呼ぶ
安全なDatalog式にするためには、以下のsyntactic restrictionがある。
(1) headに現れる変数は必ずbodyに現れる必要がある。
(2) negativeな述語に現れる変数はpositiveな述語に現れる必要がある。
```

### 文字列リテラルについて

文字列リテラルはクオートで囲まれるようにして欲しい。