### PR TITLE
inlining コマンドを実装

### DIFF
--- a/bin/dl2u.ml
+++ b/bin/dl2u.ml
@@ -1,0 +1,17 @@
+open Birds
+let _ =
+  if Array.length Sys.argv < 2 then
+    print_endline "Invalid arguments. File name must be passed."
+  else begin
+    let filename = Sys.argv.(1) in
+    let chan = open_in filename in
+    let lexbuf = Lexing.from_channel chan in
+    let ast = Parser.main Lexer.token lexbuf in
+    match Ast2sql.convert_expr_to_operation_based_sql ast with
+    | Result.Error err ->
+      print_endline @@ Ast2sql.show_error err
+    | Result.Ok operations ->
+      List.iter (fun op ->
+        print_endline @@ Ast2sql.stringify_sql_operation op
+      ) operations
+  end

--- a/bin/dune
+++ b/bin/dune
@@ -5,6 +5,12 @@
  (libraries birds sql))
 
 (executable
+ (public_name dl2u)
+ (name dl2u)
+ (modules dl2u)
+ (libraries birds))
+
+(executable
  (public_name parse)
  (name parse)
  (modules parse)

--- a/bin/dune
+++ b/bin/dune
@@ -9,6 +9,12 @@
  (name dl2u)
  (modules dl2u)
  (libraries birds))
+ 
+(executable
+  (public_name inlining)
+  (name inlining)
+  (modules inlining)
+  (libraries birds))
 
 (executable
  (public_name parse)

--- a/bin/inlining.ml
+++ b/bin/inlining.ml
@@ -1,0 +1,18 @@
+open Birds
+
+let _ =
+  if Array.length Sys.argv < 2 then
+    print_endline "Invalid arguments. File name must be passed."
+  else begin
+    let filename = Sys.argv.(1) in
+    let chan = open_in filename in
+    let lexbuf = Lexing.from_channel chan in
+    let ast = Parser.main Lexer.token lexbuf in
+    let rules = ast.rules in
+    match Inlining.inline_rules rules with
+    | Result.Error err ->
+      print_endline @@ Inlining.string_of_error err
+    | Result.Ok rules ->
+      let ast = Expr.{ ast with rules } in
+      print_endline @@ Expr.to_string ast
+  end

--- a/examples/dl2u_sample.dl
+++ b/examples/dl2u_sample.dl
@@ -1,0 +1,5 @@
+source ed('EMP_NAME':string,'DEPT_NAME':string).
+source eed('EMP_NAME':string,'DEPT_NAME':string).
++eed(E, D) :- ed(E, D), D = 'A', E <> 'Joe', ¬eed(E, D).
+-eed(E, D) :- ed(V1, D), eed(E, D), E = 'Joe', D = 'A', V1 <> 'Joe', ¬eed(V1, D).
++ed(E, D) :- ed(V1, D), E = 'Joe', D = 'A', V1 <> 'Joe', ¬ed(E, D), ¬eed(V1, D).


### PR DESCRIPTION
#### *注意*
この PR は https://github.com/proof-ninja/BIRDS/pull/22 の変更内容を含んでいます。
マージする際は、必ず上記 PR を先にマージしてください。

### 概要

以下のコマンドを実装しています。

```
(2) inlining (PR95)
入力：Datalogを記したファイル
出力：Datalog
```

### 使い方

`dune exec` コマンドで実行します。
引数に Datalog 式の記されたファイルを渡すと、それをインライン化した式を返します。

```bash
> dune exec bin/inlining.exe --profile release -- examples/basic_sample.dl
```

### 実行結果

`inlining.dl`
```
+foo(X) :- bar(X).
bar(Y) :- qux(Y).
```

出力
```sql
+foo(X) :- qux(X).
bar(Y) :- qux(Y).
```