### PR TITLE
u2dl を SQL INSERT 文に対応

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,3 +3,9 @@
  (name u2dl)
  (modules u2dl)
  (libraries birds sql))
+
+(executable
+ (public_name parse)
+ (name parse)
+ (modules parse)
+ (libraries birds sql))

--- a/bin/parse.ml
+++ b/bin/parse.ml
@@ -1,0 +1,25 @@
+open Birds
+
+let check_arguments_count argv =
+  if Array.length argv < 2 then
+    Result.Error "Invalid arguments. SQL file name must be passed."
+  else
+    Result.Ok ()
+
+let open_sql_ast filename =
+  let chan = open_in filename in
+  let lexbuf = Lexing.from_channel chan in
+  let ast = Sql.Parser.statement Sql.Lexer.token lexbuf in
+  Result.Ok ast
+
+let main =
+  let open Utils.ResultMonad in
+  check_arguments_count Sys.argv >>= fun _ ->
+  open_sql_ast Sys.argv.(1) >>= fun sql ->
+  return @@ print_endline @@ Sql.Ast.to_string sql
+
+let _ =
+  match main with
+  | Result.Ok _ -> ()
+  | Result.Error err -> print_endline err
+

--- a/bin/u2dl.ml
+++ b/bin/u2dl.ml
@@ -9,7 +9,7 @@ let check_arguments_count argv =
 let open_sql_ast filename =
   let chan = open_in filename in
   let lexbuf = Lexing.from_channel chan in
-  let ast = Sql.Parser.update Sql.Lexer.token lexbuf in
+  let ast = Sql.Parser.statement Sql.Lexer.token lexbuf in
   Result.Ok ast
 
 let open_view_ast filename =
@@ -25,7 +25,7 @@ let extract_schema expr =
   | None -> Result.Error "Invalid schema file. A view definition must be."
 
 let convert_to_dl sql cols =
-  match Sql2ast.update_to_datalog sql cols with
+  match Sql2ast.to_datalog sql cols with
   | Result.Ok _ as succ -> succ
   | Result.Error err -> Result.Error (Sql2ast.string_of_error err)
 

--- a/examples/e1.dl
+++ b/examples/e1.dl
@@ -1,0 +1,6 @@
+v(A) :- s(A,B).
+-s(A,B) :- s(A,B), -v(A).
++s(A,B) :- +v(A), not s(A,_), not -s(_,_), B=-1.
++s(A,B) :- +v(A), not s(A,_), -s(_,B).
++v(GV1) :- GV1 = 4 , -v(V12).
+-v(GV1) :- v(GV1) , GV1 = 1 , GV1 <> 4.

--- a/examples/insert_sample.dl
+++ b/examples/insert_sample.dl
@@ -1,0 +1,1 @@
+view ced('ID':int, 'DEPT_NAME':string).

--- a/examples/insert_sample.sql
+++ b/examples/insert_sample.sql
@@ -1,0 +1,1 @@
+INSERT INTO ced VALUES (1, 'A'), (2, 'B');

--- a/src/sql/ast.ml
+++ b/src/sql/ast.ml
@@ -41,7 +41,10 @@ type sql_constraint =
 type where_clause =
   | Where of sql_constraint list
 
-type update =
+type insert_value = vterm list
+
+type statement =
+  | InsertInto of table_name * insert_value list
   | UpdateSet of table_name * (column * vterm) list * where_clause option
 
 let string_of_binary_operator = function
@@ -91,6 +94,21 @@ let string_of_constraint = function
         (string_of_vterm right)
 
 let to_string = function
+  | InsertInto (table_name, values) ->
+    let values = values
+      |> List.map (fun value ->
+      let value = value
+        |> List.map string_of_vterm
+        |> String.concat ", "
+      in
+      Printf.sprintf "( %s )" value
+      )
+      |> String.concat "\n"
+    in
+    "INSERT INTO\n" ^
+    "  " ^ table_name ^ "\n" ^
+    "VALUES\n" ^
+    values
   | UpdateSet (table_name, sets, where) ->
     let string_of_set (col, vterm) =
       Printf.sprintf "  %s = %s" (string_of_column col) (string_of_vterm vterm)

--- a/src/sql/lexer.mll
+++ b/src/sql/lexer.mll
@@ -16,6 +16,12 @@
       raise (LexErr (spec_error (lexeme lexbuf) (lexeme_start_p lexbuf) (lexeme_end_p lexbuf)))
 
     let keywords = [
+        "insert", INSERT;
+        "INSERT", INSERT;
+        "into", INTO;
+        "INTO", INTO;
+        "values", VALUES;
+        "VALUES", VALUES;
         "update", UPDATE;
         "UPDATE", UPDATE;
         "where", WHERE;

--- a/src/sql/parser.mly
+++ b/src/sql/parser.mly
@@ -2,7 +2,7 @@
 %token <string> IDENT TEXT
 %token <float> FLOAT
 %token LPAREN RPAREN COMMA EOF DOT NULL
-%token UPDATE WHERE EQUAL ASTERISK SET AND CONCAT_OP
+%token INSERT INTO VALUES UPDATE WHERE EQUAL ASTERISK SET AND CONCAT_OP
 %token NUM_DIV_OP NUM_NEQ_OP PLUS MINUS
 
 %left CONCAT_OP
@@ -12,15 +12,24 @@
 %left ASTERISK NUM_DIV_OP
 %nonassoc UNARY_MINUS
 
-%start <Ast.update> update
+%start <Ast.statement> statement
 
 %%
 
-  update:
-  | update_stmt EOF { $1 }
+  statement:
+  | insert EOF { $1 }
+  | update EOF { $1 }
   ;
 
-  update_stmt:
+  insert:
+  | INSERT INTO table=IDENT VALUES vs=commas(values) { Ast.InsertInto (table, vs) }
+  ;
+
+  values:
+  | LPAREN es=commas(vterm) RPAREN { es }
+  ;
+
+  update:
   | UPDATE table=IDENT SET ss=commas(set_column) w=where? { Ast.UpdateSet (table, ss, w) }
   ;
 

--- a/src/sql2ast.mli
+++ b/src/sql2ast.mli
@@ -3,9 +3,9 @@ type error
 val string_of_error : error -> string
 
 (**
-  * @param update AST of the SQL UPDATE statement.
+  * @param SQL statement.
   * @param columns List of column names of the table to be queried.
   *
   * @return List of rules in datalog language, or failure.
   *)
-val update_to_datalog : Sql.Ast.update -> Sql.Ast.column_name list -> (Expr.rule list, error) result
+val to_datalog : Sql.Ast.statement -> Sql.Ast.column_name list -> (Expr.rule list, error) result

--- a/src/utils.ml
+++ b/src/utils.ml
@@ -645,6 +645,7 @@ module ResultMonad : sig
   val map_err : ('e1 -> 'e2) -> ('a, 'e1) result -> ('a, 'e2) result
   val foldM : ('a -> 'b -> ('a, 'e) result) -> 'a -> 'b list -> ('a, 'e) result
   val mapM : ('a -> ('b, 'e) result) -> 'a list -> ('b list, 'e) result
+  val sequence : (('a, 'e) result) list -> ('a list, 'e) result
   val ( >>= ) : ('a, 'e) result -> ('a -> ('b, 'e) result) -> ('b, 'e) result
 end = struct
 
@@ -680,6 +681,8 @@ end = struct
       return (y :: acc)
     ) [] >>= fun acc ->
     return (List.rev acc)
+
+  let sequence vs = mapM Fun.id vs
 end
 
 

--- a/test/sql2ast_test.ml
+++ b/test/sql2ast_test.ml
@@ -235,5 +235,46 @@ let main () =
           ]
         )
       ]
+    };
+    {
+      title = "Basic INSERT";
+      (*
+       * SQL:
+       *   INSERT INTO
+       *     ced
+       *   VALUES
+       *   ( 'A', 'X' ),
+       *   ( 'B', 'Y' )
+       *
+       * datalog:
+       *   +ced(NAME, DEPT) :- NAME = 'A', DEPT = 'X'.
+       *   +ced(NAME, DEPT) :- NAME = 'B', DEPT = 'Y'.
+       *)
+      input = (
+        Sql.InsertInto (
+          "ced",
+          [
+            [Sql.Const (Sql.String "A"); Sql.Const (Sql.String "X")];
+            [Sql.Const (Sql.String "B"); Sql.Const (Sql.String "Y")]
+          ]
+        ),
+        ["NAME"; "DEPT"]
+      );
+      expected = [
+        (
+          Deltainsert ("ced", [NamedVar "NAME"; NamedVar "DEPT"]),
+          [
+            Equat (Equation ("=", (Var (NamedVar "NAME")), (Var (ConstVar (String "A")))));
+            Equat (Equation ("=", (Var (NamedVar "DEPT")), (Var (ConstVar (String "X")))));
+          ]
+        );
+        (
+          Deltainsert ("ced", [NamedVar "NAME"; NamedVar "DEPT"]),
+          [
+            Equat (Equation ("=", (Var (NamedVar "NAME")), (Var (ConstVar (String "B")))));
+            Equat (Equation ("=", (Var (NamedVar "DEPT")), (Var (ConstVar (String "Y")))));
+          ]
+        )
+      ]
     }
   ]

--- a/test/sql2ast_test.ml
+++ b/test/sql2ast_test.ml
@@ -5,7 +5,7 @@ module Sql = Sql.Ast
 
 type test_case = {
   title : string;
-  input : Sql.update * Sql.column_name list;
+  input : Sql.statement * Sql.column_name list;
   expected : Expr.rule list
 }
 
@@ -23,7 +23,7 @@ let run_test {input; expected; _} =
       |> String.concat "; "
   in
   let (update, columns) = input in
-  Sql2ast.update_to_datalog update columns >>= fun actual ->
+  Sql2ast.to_datalog update columns >>= fun actual ->
   let actual_str = string_of_rules actual in
   let expected_str = string_of_rules expected in
   if String.equal actual_str expected_str then
@@ -51,7 +51,6 @@ let run_tests (test_cases : test_case list) : bool =
   ) false
 
 let main () =
-  let open Sql2ast in
   let open Expr in
   run_tests [
     {


### PR DESCRIPTION
## 概要

https://hackmd.io/ORPwamPPSO2pvYej8PF4PQ
SQL INSERT 文を読み取ります。

## 確認方法

以下のようなファイルを用意。

`insert.sql`
```sql
INSERT INTO ced VALUES (1, 'A'), (2, 'B');
```

`insert.dl`
```dl
view ced('ID':int, 'DEPT_NAME':string).
```

dune コマンドで実行。

```bash
$ dune exec bin/u2dl.exe -- insert.sql insert.dl
```

出力。
```
view ced('ID':int, 'DEPT_NAME':string).
+ced(ID, DEPT_NAME) :- ID = 1 , DEPT_NAME = 'A'.
+ced(ID, DEPT_NAME) :- ID = 2 , DEPT_NAME = 'B'.
```

## BNF

https://github.com/proof-ninja/BIRDS/pull/25#issuecomment-1690206058 に加えて以下の通り。

```
<statement> ::= <insert>
              | <update>

<insert> ::= "INSERT" "INTO" <table_name> "VALUES" <insert_values> { "," <insert_values> }

<insert_values> ::= "(" <vterm> { "," <vterm> } ")"
```