### PR TITLE
SQL WHERE 内での OR 条件に対応

### DIFF
--- a/examples/update_or.dl
+++ b/examples/update_or.dl
@@ -1,0 +1,1 @@
+view t('A':string, 'B':string, 'C':string, 'D':string, 'E':string).

--- a/examples/update_or.sql
+++ b/examples/update_or.sql
@@ -1,0 +1,3 @@
+UPDATE t
+SET A = 'a', B = 'b'
+WHERE C = 'x' AND D = 'y' OR E = 'z';

--- a/src/sql/lexer.mll
+++ b/src/sql/lexer.mll
@@ -30,6 +30,8 @@
         "SET", SET;
         "and", AND;
         "AND", AND;
+        "or", OR;
+        "OR", OR;
     ]
 }
 let digit = ['0'-'9']
@@ -56,7 +58,6 @@ rule token = parse
   | "NULL" | "null" { NULL }
   | '=' { EQUAL }
   | '*' { ASTERISK }
-  | "||" { CONCAT_OP }
   | '/' { NUM_DIV_OP }
   | "!=" | "<>" { NUM_NEQ_OP }
   | '+' { PLUS }

--- a/src/sql/parser.mly
+++ b/src/sql/parser.mly
@@ -2,10 +2,10 @@
 %token <string> IDENT TEXT
 %token <float> FLOAT
 %token LPAREN RPAREN COMMA EOF DOT NULL
-%token INSERT INTO VALUES UPDATE WHERE EQUAL ASTERISK SET AND CONCAT_OP
+%token INSERT INTO VALUES UPDATE WHERE EQUAL ASTERISK SET AND OR
 %token NUM_DIV_OP NUM_NEQ_OP PLUS MINUS
 
-%left CONCAT_OP
+%left OR
 %left AND
 %nonassoc EQUAL NUM_NEQ_OP
 %left PLUS MINUS
@@ -30,7 +30,7 @@
   ;
 
   update:
-  | UPDATE table=IDENT SET ss=commas(set_column) w=where? { Ast.UpdateSet (table, ss, w) }
+  | UPDATE table=IDENT SET ss=commas(set_column) ws=wheres? { Ast.UpdateSet (table, ss, Option.value ~default:[] ws) }
   ;
 
   set_column:
@@ -67,11 +67,14 @@
   | MINUS { Ast.Minus }
   | ASTERISK { Ast.Times }
   | NUM_DIV_OP { Ast.Divides }
-  | CONCAT_OP { Ast.Lor }
+  ;
+
+  wheres:
+  | WHERE ws=ors(where) { ws }
   ;
 
   where:
-  | WHERE cs=ands(sql_constraint) { Ast.Where cs }
+  | cs=ands(sql_constraint) { cs }
   ;
 
   sql_constraint:
@@ -85,4 +88,5 @@
   ;
 
 %inline commas(X): l=separated_nonempty_list(COMMA, X) { l }
+%inline ors(X): l=separated_nonempty_list(OR, X) { l }
 %inline ands(X): l=separated_nonempty_list(AND, X) { l }


### PR DESCRIPTION
## 概要
変更の本質はこちら: https://github.com/proof-ninja/BIRDS/commit/0ea7cbdf74dab4f75c079126325878875bcf141b

https://hackmd.io/ORPwamPPSO2pvYej8PF4PQ
SQL の WHERE 節内で OR 条件を利用できるように修正します。

## 確認方法

`update.sql`
```sql
UPDATE t
SET A = 'a', B = 'b'
WHERE C = 'x' AND D = 'y' OR E = 'z';
```

`update.dl`
```dl
view t('A':string, 'B':string, 'C':string, 'D':string, 'E':string).
```

dune コマンドで実行。

```bash
$ dune exec bin/u2dl.exe -- update.sql update.dl
```

出力。
```
view t('A':string, 'B':string, 'C':string, 'D':string, 'E':string).
-t(GENV1, GENV2, GENV3, GENV4, GENV5) :- t(GENV1, GENV2, GENV3, GENV4, GENV5) , GENV3 = 'x' , GENV4 = 'y' , GENV1 <> 'a'.
-t(GENV1, GENV2, GENV3, GENV4, GENV5) :- t(GENV1, GENV2, GENV3, GENV4, GENV5) , GENV5 = 'z' , GENV1 <> 'a'.
-t(GENV1, GENV2, GENV3, GENV4, GENV5) :- t(GENV1, GENV2, GENV3, GENV4, GENV5) , GENV3 = 'x' , GENV4 = 'y' , GENV2 <> 'b'.
-t(GENV1, GENV2, GENV3, GENV4, GENV5) :- t(GENV1, GENV2, GENV3, GENV4, GENV5) , GENV5 = 'z' , GENV2 <> 'b'.
+t(GENV1, GENV2, GENV3, GENV4, GENV5) :- GENV1 = 'a' , GENV2 = 'b' , -t(GENV1_2, GENV2_2, GENV3, GENV4, GENV5).
```

## BNF

以下のように修正される。

```
<update> ::= "UPDATE" <table_name> "SET" <set_columns> [ "WHERE" <where_clauses> ]

<where_clauses> ::= <where_clause> { "OR" <where_clause> }

<where_clause> ::= <constraint> { "AND" <constraint> }
```