### PR TITLE
Effect-basedへの変換 Step1

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -33,3 +33,10 @@
  (name parse)
  (modules parse)
  (libraries birds sql))
+
+(executable
+  (public_name incrementalization)
+  (name incrementalization)
+  (modules incrementalization)
+  (libraries birds))
+

--- a/bin/incrementalization.ml
+++ b/bin/incrementalization.ml
@@ -1,0 +1,17 @@
+open Birds
+
+let _ =
+  if Array.length Sys.argv < 2 then
+    print_endline "Invalid arguments. File name must be passed."
+  else begin
+    let filename = Sys.argv.(1) in
+    let chan = open_in filename in
+    let lexbuf = Lexing.from_channel chan in
+    let ast = Parser.main Lexer.token lexbuf in
+    match Incrementalization.incrementalization_ast ast with
+    | Result.Error err ->
+      print_endline @@ Incrementalization.string_of_error err
+    | Result.Ok rules ->
+      let ast = Expr.{ ast with rules } in
+      print_endline @@ Expr.to_string ast
+  end

--- a/examples/incrementalization1.dl
+++ b/examples/incrementalization1.dl
@@ -1,0 +1,9 @@
+source ed('EMP_NAME':string,'DEPT_NAME':string).
+source eed('EMP_NAME':string,'DEPT_NAME':string).
+view ced('EMP_NAME':string, 'DEPT_NAME':string).
+
+ced(E,D) :- ed(E,D), not eed(E,D).
+
++ed(E, D) :- ced(E, D), NOT ed(E, D).
+-eed(E, D) :- ced(E, D), eed(E, D).
++eed(E, D) :- ed(E, D), NOT ced(E, D), NOT eed(E, D).

--- a/examples/incrementalization2.dl
+++ b/examples/incrementalization2.dl
@@ -1,0 +1,9 @@
+source s('A':int, 'B':string).
+view v('A':int).
+
+%view definition
+v(A) :- s(A,B).
+
+-s(A,B) :- s(A,B), not v(A).
++s(A,B) :- v(A), not s(A,_), not -s(_,_), B='a'.
++s(A,B) :- v(A), not s(A,_), -s(_,B).

--- a/examples/incrementalization3.dl
+++ b/examples/incrementalization3.dl
@@ -1,0 +1,21 @@
+source b('B':string, 'C':real).
+source a('A':real, 'B':string).
+view v('A':real, 'B':string, 'C':real).
+
+% primary key
+% A -> B on view v
+_|_ :- v(A, B1, _), v(A, B2, _), B1 <> B2.
+% B -> C on view v
+_|_ :- v(_, B, C1), v(_, B, C2), C1 <> C2.
+
+% foreign key
+_|_ :- a(_, B), not b(B, _).
+
+% view definition
+v(A, B, C) :- a(A, B), b(B, C).
+
+% update strategy
+-a(A, B) :- a(A, B), not v(A, B, _).
+-b(B, C) :- b(B, C), v(_, B, _), not v(_, B, C).
++a(A, B) :- v(A, B, _), not a(A, B).
++b(B, C) :- v(_, B, C), not b(B, C).

--- a/src/incrementalization.ml
+++ b/src/incrementalization.ml
@@ -1,0 +1,52 @@
+
+open Expr
+open Utils
+
+(** The prefix used for variables generated during incrementalization. *)
+let updated_variable_prefix = "__updated__"
+
+type error =
+  | NoViewVariable
+
+let string_of_error = function
+  | NoViewVariable ->
+      "There is no view in this program."
+
+let incrementalization_ast (ast: expr): (rule list, error) result =
+  let open ResultMonad in
+
+  match ast.view with
+    | Some (view_name, params) ->
+
+      let updated_view_name = updated_variable_prefix ^ view_name  in
+
+      let replace_name (name: string): string =
+        if name = view_name then updated_view_name else name 
+      in
+
+      let convert_rterm: rterm -> rterm = function
+        | Pred (name, vars) -> Pred (replace_name name, vars)
+        | Deltainsert (name, vars) -> Deltainsert (replace_name name, vars)
+        | Deltadelete (name, vars) -> Deltadelete (replace_name name, vars)
+      in
+
+      let convert_term: term -> term = function
+        | Rel rterm -> Rel (convert_rterm rterm)
+        | Not rterm -> Not (convert_rterm rterm)
+        | Equat eterm -> Equat eterm
+        | Noneq eterm -> Noneq eterm
+        | ConstTerm bool -> ConstTerm bool 
+      in
+
+      let rules = ast.rules |> List.map(fun (head, body) -> (head, body |> List.map convert_term)) in
+
+      let param_vars = params |> List.map(fun (var_name, _) -> NamedVar(var_name)) in
+
+      let delete_rule = Pred (updated_view_name, param_vars), Rel (Pred (view_name, param_vars)) :: Not (Deltadelete (view_name, param_vars)) :: [] in
+
+      let insert_rule = Pred (updated_view_name, param_vars), Rel (Deltainsert (view_name, param_vars)) :: [] in
+
+      return (delete_rule :: insert_rule :: List.rev rules)
+
+    | None -> err NoViewVariable
+

--- a/src/incrementalization.mli
+++ b/src/incrementalization.mli
@@ -1,0 +1,8 @@
+
+open Expr
+
+type error
+
+val string_of_error : error -> string
+
+val incrementalization_ast : expr -> (rule list, error) result


### PR DESCRIPTION
実装方針: https://hackmd.io/cEqNH-opQ2aw1gRjvnm67g

Effect-basedへの変換 Step1 を実装します

## 実行方法

```
dune exec incrementalization examples/incrementalization1.dl
```

## 動作確認

### examples/incrementalization2.dl

#### 入力

```
source s('A':int, 'B':string).
view v('A':int).

%view definition
v(A) :- s(A,B).

-s(A,B) :- s(A,B), not v(A).
+s(A,B) :- v(A), not s(A,_), not -s(_,_), B='a'.
+s(A,B) :- v(A), not s(A,_), -s(_,B).
```

#### 望ましい出力

```
source s('A':int, 'B':string).
view v('A':int).

%view definition
v(A) :- s(A,B).

uv(A) :- +v(A).
uv(A) :- v(A), not -v(A).

(a). -s(A,B) :- s(A,B), -v(A).
(b). +s(A,B) :- uv(A), not s(A,_), not -s(_,_), B='a'.
(c). +s(A,B) :- uv(A), not s(A,_), -s(_,B).
```

#### 出力

```
source s('A':int, 'B':string).        
view v('A':int).
__updated__v(A) :- v(A) , not -v(A).
__updated__v(A) :- +v(A).
v(A) :- s(A, B).
-s(A, B) :- s(A, B) , not __updated__v(A).
+s(A, B) :- __updated__v(A) , not s(A, _) , not -s(_, _) , B = 'a'.
+s(A, B) :- __updated__v(A) , not s(A, _) , -s(_, B).
```

`uv` に相当するのが `__updated__v` である
また、 `__updated__v` に関するルールの挿入位置が望ましい出力とは若干異なる

### examples/incrementalization3.dl

#### 入力

```
source b('B':string, 'C':real).
source a('A':real, 'B':string).
view v('A':real, 'B':string, 'C':real).

% primary key
% A -> B on view v
_|_ :- v(A, B1, _), v(A, B2, _), B1 <> B2.
% B -> C on view v
_|_ :- v(_, B, C1), v(_, B, C2), C1 <> C2.

% foreign key
_|_ :- a(_, B), not b(B, _).

% view definition
v(A, B, C) :- a(A, B), b(B, C).

% update strategy
-a(A, B) :- a(A, B), not v(A, B, _).
-b(B, C) :- b(B, C), v(_, B, _), not v(_, B, C).
+a(A, B) :- v(A, B, _), not a(A, B).
+b(B, C) :- v(_, B, C), not b(B, C).
```

#### 望ましい出力

```
source b('B':string, 'C':real).
source a('A':real, 'B':string).
view v('A':real, 'B':string, 'C':real).

% primary key
% A -> B on view v
_|_ :- v(A, B1, _), v(A, B2, _), B1 <> B2.
% B -> C on view v
_|_ :- v(_, B, C1), v(_, B, C2), C1 <> C2.

% foreign key
_|_ :- a(_, B), not b(B, _).

% view definition
v(A, B, C) :- a(A, B), b(B, C).

uv(A,B,C) :- v(A,B,C), not -v(A,B,C).
uv(A,B,C) :- +v(A,B,C).

% update strategy
-a(A, B) :- a(A, B), not uv(A, B, _).
-b(B, C) :- b(B, C), uv(_, B, _), not uv(_, B, C).
+a(A, B) :- uv(A, B, _), not a(A, B).
+b(B, C) :- uv(_, B, C), not b(B, C).
```

#### 出力

```
source a('A':real, 'B':string).       
source b('B':string, 'C':real).
view v('A':real, 'B':string, 'C':real).
⊥() :- a(_, B) , not b(B, _).
⊥() :- v(_, B, C1) , v(_, B, C2) , C1 <> C2.
⊥() :- v(A, B1, _) , v(A, B2, _) , B1 <> B2.
__updated__v(A, B, C) :- v(A, B, C) , not -v(A, B, C).
__updated__v(A, B, C) :- +v(A, B, C).
v(A, B, C) :- a(A, B) , b(B, C).
-a(A, B) :- a(A, B) , not __updated__v(A, B, _).
-b(B, C) :- b(B, C) , __updated__v(_, B, _) , not __updated__v(_, B, C).
+a(A, B) :- __updated__v(A, B, _) , not a(A, B).
+b(B, C) :- __updated__v(_, B, C) , not b(B, C).
```

### examples/incrementalization1.dl

#### 入力

```
source ed('EMP_NAME':string,'DEPT_NAME':string).
source eed('EMP_NAME':string,'DEPT_NAME':string).
view ced('EMP_NAME':string, 'DEPT_NAME':string).

ced(E,D) :- ed(E,D), not eed(E,D).

+ed(E, D) :- ced(E, D), NOT ed(E, D).
-eed(E, D) :- ced(E, D), eed(E, D).
+eed(E, D) :- ed(E, D), NOT ced(E, D), NOT eed(E, D).
```

#### 望ましい出力

```
source ed('EMP_NAME':string,'DEPT_NAME':string).
source eed('EMP_NAME':string,'DEPT_NAME':string).
view ced('EMP_NAME':string, 'DEPT_NAME':string).

ced(E,D) :- ed(E,D), not eed(E,D).

+ed(E, D) :- +ced(E, D), NOT ed(E, D).
-eed(E, D) :- +ced(E, D), eed(E, D).
+eed(E, D) :- ed(E, D), -ced(E, D), NOT eed(E, D).
```

#### 出力

```
source eed('EMP_NAME':string, 'DEPT_NAME':string).
source ed('EMP_NAME':string, 'DEPT_NAME':string).
view ced('EMP_NAME':string, 'DEPT_NAME':string).
__updated__ced(EMP_NAME, DEPT_NAME) :- ced(EMP_NAME, DEPT_NAME) , not -ced(EMP_NAME, DEPT_NAME).
__updated__ced(EMP_NAME, DEPT_NAME) :- +ced(EMP_NAME, DEPT_NAME).
ced(E, D) :- ed(E, D) , not eed(E, D).
+ed(E, D) :- __updated__ced(E, D) , not ed(E, D).
-eed(E, D) :- __updated__ced(E, D) , eed(E, D).
+eed(E, D) :- ed(E, D) , not __updated__ced(E, D) , not eed(E, D).
```

LVGN判定は未実装のため非LVGNの場合と同様の出力になっている (Step2のプルリクで対応)



