### PR TITLE
negative な場合に inlining を行わないように修正

### DIFF
--- a/examples/neginl1.dl
+++ b/examples/neginl1.dl
@@ -1,0 +1,2 @@
+cp_v() :- +v(N,T), T <> 'A', T <> B.
++a(N) :- +v(N,T), not a(N), T='A', not cp_v().

--- a/examples/neginl1.dl
+++ b/examples/neginl1.dl
@@ -1,2 +1,2 @@
-cp_v() :- +v(N,T), T <> 'A', T <> B.
+cp_v() :- +v(N,T), T <> 'A', T <> 'B'.
 +a(N) :- +v(N,T), not a(N), T='A', not cp_v().

--- a/examples/neginl2.dl
+++ b/examples/neginl2.dl
@@ -1,0 +1,10 @@
+fd1() :- +ac(_,_,BRAND_ID,BRAND_NAME1), +ac(_,_,BRAND_ID,BRAND_NAME2), BRAND_NAME1 <> BRAND_NAME2.
+fd1() :- dac(_,_,BRAND_ID,BRAND_NAME1), +ac(_,_,BRAND_ID,BRAND_NAME2), BRAND_NAME1 <> BRAND_NAME2.
+fd2() :- +ac(CAR_ID, CAR_NAME1, _, _), +ac(CAR_ID, CAR_NAME2, _, _), CAR_NAME1 <> CAR_NAME2.
+fd2() :- +ac(CAR_ID, CAR_NAME1, _, _), dac(CAR_ID, CAR_NAME2, _, _), CAR_NAME1 <> CAR_NAME2.
+fd3() :- +ac(CAR_ID, _, BRAND_ID1, _), +ac(CAR_ID, _, BRAND_ID2, _), BRAND_ID1 <> BRAND_ID2.
+fd3() :- +ac(CAR_ID, _, BRAND_ID1, _), dac(CAR_ID, _, BRAND_ID2, _), BRAND_ID1 <> BRAND_ID2.
+fd() :- not fd1(), not fd2(), not fd3().
+-bi(BID, BN) :- db(BID, BN), iac(_, _, BID, _), not iac(_, _, BID, BN), fd().
++ci(CID, CN, BID) :- +ac(CID, CN, BID, _), not dc(CID, CN, BID), fd().
++bi(BID, BN) :- +ac(_, _, BID, BN), not db(BID, BN), fd().

--- a/src/inlining.ml
+++ b/src/inlining.ml
@@ -465,28 +465,6 @@ let inline_rule_abstraction (state : state) (improg_inlined : intermediate_progr
               return (state, accs |> List.map (fun acc -> clause :: acc))
         end
 
-    (* | ImNegative (impred, imargs) ->
-      begin
-        match improg_inlined |> PredicateMap.find_opt impred with
-        | Some ruleabsset ->
-            let state, ruleabss =
-              ruleabsset
-              |> RuleAbstractionSet.elements
-              |> negate_rule_abstractions state
-            in
-            ruleabss |> foldM (fun (state, clauses_acc) ruleabs ->
-              reduce_rule state ruleabs imargs >>= fun (state, clauses) ->
-              return (state, clauses :: clauses_acc)
-            ) (state, []) >>= fun (state, clauses_acc) ->
-            let clausess = List.rev clauses_acc in
-            return (state, accs |> List.map (fun acc ->
-              clausess |> List.map (fun clauses -> List.rev_append clauses acc)
-            ) |> List.concat)
-
-        | None ->
-            return (state, accs |> List.map (fun acc -> clause :: acc))
-      end *)
-
     | _ ->
       (* Clauses other than positive applications are not inlined: *)
         return (state, accs |> List.map (fun acc -> clause :: acc))

--- a/src/inlining.ml
+++ b/src/inlining.ml
@@ -465,7 +465,7 @@ let inline_rule_abstraction (state : state) (improg_inlined : intermediate_progr
               return (state, accs |> List.map (fun acc -> clause :: acc))
         end
 
-    | ImNegative (impred, imargs) ->
+    (* | ImNegative (impred, imargs) ->
       begin
         match improg_inlined |> PredicateMap.find_opt impred with
         | Some ruleabsset ->
@@ -485,7 +485,7 @@ let inline_rule_abstraction (state : state) (improg_inlined : intermediate_progr
 
         | None ->
             return (state, accs |> List.map (fun acc -> clause :: acc))
-      end
+      end *)
 
     | _ ->
       (* Clauses other than positive applications are not inlined: *)

--- a/test/inlining_test.ml
+++ b/test/inlining_test.ml
@@ -185,7 +185,7 @@ let main () =
             "g(Y) :- Y = 42 , true."
           ]
       };
-      {
+      (* {
         title = "inlining negative predications";
         input = [
           (!: "cedp" ["E"; "D"], [ Rel (Deltainsert ("ced", [ NamedVar "E"; NamedVar "D" ])) ]);
@@ -220,7 +220,7 @@ let main () =
             "cedp(E, D) :- ced(E, D) , true.";
             "cedp(E, D) :- +ced(E, D).";
           ]
-      }
+      } *)
     ]
   in
   run_tests test_cases

--- a/test/inlining_test.ml
+++ b/test/inlining_test.ml
@@ -185,6 +185,30 @@ let main () =
             "g(Y) :- Y = 42 , true."
           ]
       };
+      {
+        title = "negative delta predicate";
+        input = [
+          (!: "cp_v" [], [
+            Rel (Deltainsert ("v", [ NamedVar "N"; NamedVar "T"]));
+            Equat (Equation ("<>", Var (NamedVar "T"), Const (String "'A'")));
+            Equat (Equation ("<>", Var (NamedVar "T"), Const (String "'B'")));
+          ]);
+          (!+ "a" ["N"], [
+            Rel (Deltainsert ("v", [ NamedVar "N"; NamedVar "T"]));
+            Not (Pred ("a", [ NamedVar "N" ]));
+            Equat (Equation ("=", Var (NamedVar "T"), Const (String "'A'")));
+            Not (Pred ("cp_v", []))
+          ])
+        ];
+        (* Input:
+         *   cp_v() :- +v(N,T), T <> 'A', T <> 'B'.
+         *   +a(N) :- +v(N,T), not a(N), T='A', not cp_v().
+         *)
+        expected = make_lines [
+          "+a(N) :- +v(N, T) , not a(N) , T = 'A' , not cp_v().";
+          "cp_v() :- +v(N, T) , T <> 'A' , T <> 'B'."
+        ]
+      };
     ]
   in
   run_tests test_cases

--- a/test/inlining_test.ml
+++ b/test/inlining_test.ml
@@ -185,42 +185,6 @@ let main () =
             "g(Y) :- Y = 42 , true."
           ]
       };
-      (* {
-        title = "inlining negative predications";
-        input = [
-          (!: "cedp" ["E"; "D"], [ Rel (Deltainsert ("ced", [ NamedVar "E"; NamedVar "D" ])) ]);
-          (!: "cedp" ["E"; "D"], [
-            Rel (Pred ("ced", [ NamedVar "E"; NamedVar "D" ]));
-            Not (Deltadelete ("ced", [ NamedVar "E"; NamedVar "D" ]));
-          ]);
-          (!+ "ed" ["E"; "D"], [
-            Rel (Pred ("cedp", [ NamedVar "E"; NamedVar "D" ]));
-            Not (Pred ("ed", [ NamedVar "E"; NamedVar "D" ]));
-          ]);
-          (!- "eed" ["E"; "D"], [
-            Rel (Pred ("cedp", [ NamedVar "E"; NamedVar "D" ]));
-            Rel (Pred ("eed", [ NamedVar "E"; NamedVar "D" ]));
-          ]);
-          (!+ "eed" ["E"; "D"], [
-            Rel (Pred ("ed", [ NamedVar "E"; NamedVar "D" ]));
-            Not (Pred ("cedp", [ NamedVar "E"; NamedVar "D" ]));
-            Not (Pred ("eed", [ NamedVar "E"; NamedVar "D" ]));
-          ]);
-          (!- "ced" ["E"; "D"], [ ConstTerm false ]);
-        ];
-        expected =
-          make_lines [
-            "-ced(E, D) :- false.";
-            "-eed(E, D) :- ced(E, D) , true , eed(E, D).";
-            "-eed(E, D) :- +ced(E, D) , eed(E, D).";
-            "+ed(E, D) :- ced(E, D) , true , not ed(E, D).";
-            "+ed(E, D) :- +ced(E, D) , not ed(E, D).";
-            "+eed(E, D) :- ed(E, D) , not ced(E, D) , not +ced(E, D) , not eed(E, D).";
-            "+eed(E, D) :- ed(E, D) , false , not +ced(E, D) , not eed(E, D).";
-            "cedp(E, D) :- ced(E, D) , true.";
-            "cedp(E, D) :- +ced(E, D).";
-          ]
-      } *)
     ]
   in
   run_tests test_cases


### PR DESCRIPTION
## 概要
https://hackmd.io/y97D-_FOS3Kw8bVpwyPsJQ#%E3%82%BF%E3%82%B9%E3%82%AFA-negative%E3%81%AEinlining%E3%82%92%E6%AD%A2%E3%82%81%E3%82%8B

タイトル通り、 negative な場合に inlining を行わないようにした。

## 動作確認

`examples/neginl1.dl` のサンプルファイル。
```dl
cp_v() :- +v(N,T), T <> 'A', T <> B.
+a(N) :- +v(N,T), not a(N), T='A', not cp_v().
```

動作確認
```bash
> dune exec bin/inlining.exe -- examples/neginl1.dl
+a(N) :- +v(N, T) , not a(N) , T = 'A' , not cp_v().
cp_v() :- +v(N, T) , T <> 'A' , T <> B.
```

## 確認事項
今回、全ての述語について negative な場合に inlining を行わないようにしたが、 delta 述語の時には安全ではないとして、非 delta 述語の場合も同様かどうか確認したいです。

例:
```dl
a(N) :- N = 1, not cp_v().
cp_v() :- +v(_, T) , T <> 'A' , T <> 'B'.
```

上のような場合でも、`a(N)` について同じように inlining を行わない方が望ましいでしょうか？
