### PR TITLE
sources に出現せず他の述語でも使われていないΔ述語を除去するようにした

### DIFF
--- a/bin/dl2u.ml
+++ b/bin/dl2u.ml
@@ -9,9 +9,9 @@ let sort rules =
   | Ok rules ->
       ok rules
 
-let simplify rules =
+let simplify rules sources =
   let open Result in
-  match Simplification.simplify rules with
+  match Simplification.simplify rules sources with
   | Error err ->
       error @@ Simplification.string_of_error err
   | Result.Ok rules ->
@@ -33,7 +33,7 @@ let convert ast =
 let main (ast : Expr.expr) =
   let open ResultMonad in
   sort ast.rules >>= fun rules ->
-  simplify rules >>= fun rules ->
+  simplify rules ast.sources >>= fun rules ->
   let ast = { ast with rules = rules } in
   convert ast
 

--- a/bin/simplification.ml
+++ b/bin/simplification.ml
@@ -9,11 +9,12 @@ let _ =
     let lexbuf = Lexing.from_channel chan in
     let ast = Parser.main Lexer.token lexbuf in
     let rules = ast.rules in
+    let sources = ast.sources in
     match Inlining.sort_rules rules with
     | Result.Error err ->
       print_endline @@ Inlining.string_of_error err
     | Result.Ok rules ->
-      match Simplification.simplify rules with
+      match Simplification.simplify rules sources with
       | Result.Error err ->
         print_endline @@ Simplification.string_of_error err
       | Result.Ok rules ->

--- a/examples/simplification3_1.dl
+++ b/examples/simplification3_1.dl
@@ -1,0 +1,8 @@
+source ps('A':int, 'B':int).
+view pv('A':int).
+-ps(A, B) :- ps(A, B) , ps(A, GENV9) , A = 1 , A <> 4.
+-pv(GENV1) :- ps(GENV1, GENV7) , GENV1 = 1 , GENV1 <> 4.
++ps(A, B) :- A = 4 , ps(GENV10, GENV11) , GENV10 = 1 , GENV10 <> 4 , not ps(A, GENV1) , ps(GENV2, B) , ps(GENV2, GENV12) , GENV2 = 1 , GENV2 <> 4.
++ps(A, B) :- A = 4 , ps(GENV13, GENV14) , GENV13 = 1 , GENV13 <> 4 , not ps(A, GENV3) , not -ps(GENV4, GENV5) , B = -100.
++pv(GENV1) :- GENV1 = 4 , ps(GENV1_2, GENV8) , GENV1_2 = 1 , GENV1_2 <> 4.
+pv(A) :- ps(A, GENV6).

--- a/examples/simplification3_2.dl
+++ b/examples/simplification3_2.dl
@@ -1,0 +1,14 @@
+source b('B':int, 'C':int).
+source a('A':int, 'B':int).
+view v('A':int, 'B':int, 'C':int).
+-a(A, B) :- a(A, B) , not __updated__v(A, B, GENV1).
+-b(B, C) :- b(B, C) , a(GENV2, B) , b(B, GENV3) , not -v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C).
+-b(B, C) :- b(B, C) , +v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C).
+-v(GENV1, GENV2, GENV3) :- a(GENV1, GENV2) , b(GENV2, GENV3) , GENV2 = 30 , GENV2 <> 60.
++a(A, B) :- a(A, B) , b(B, GENV5) , not -v(A, B, GENV5) , not a(A, B).
++a(A, B) :- +v(A, B, GENV5) , not a(A, B).
++b(B, C) :- a(GENV6, B) , b(B, C) , not -v(GENV6, B, C) , not b(B, C).
++b(B, C) :- +v(GENV6, B, C) , not b(B, C).
+__updated__v(A, B, C) :- a(A, B) , b(B, C) , not -v(A, B, C).
+__updated__v(A, B, C) :- +v(A, B, C).
+v(A, B, C) :- a(A, B) , b(B, C).

--- a/src/simplification.ml
+++ b/src/simplification.ml
@@ -628,38 +628,36 @@ let resolve_undefined_predicates (imrules : intermediate_rule list) : intermedia
 module TableNameSet = Set.Make(String)
 
 
-let remove_unused_rules (imrules : intermediate_rule list) : intermediate_rule list =
-  List.fold_right (fun imrule (table_name_set, acc) ->
+let remove_unused_rules (sources : TableNameSet.t) (imrules : intermediate_rule list) : intermediate_rule list =
+  List.fold_right (fun imrule (pred_set, acc) ->
     let { positive_terms; negative_terms; _ } = imrule in
     let terms = PredicateMap.union (fun _ x _ -> Some x) positive_terms negative_terms in
-    let table_names =
+    let preds =
       terms
       |> PredicateMap.bindings
-      |> List.filter_map (fun (pred, _) ->
-        match pred with
-        | ImPred t ->
-            Some t
-        | ImDeltaInsert _
-        | ImDeltaDelete _ ->
-            None
-      )
+      |> List.map fst
     in
-    let new_table_name_set =
-      table_name_set
-      |> TableNameSet.add_seq @@ List.to_seq table_names
+    let new_pred_set =
+      pred_set
+      |> PredicateSet.add_seq @@ List.to_seq preds
     in
-    match imrule.head_predicate with
-    | ImDeltaInsert _
-    | ImDeltaDelete _ ->
-        (new_table_name_set, imrule :: acc)
-
-    | ImPred table_name when table_name_set |> TableNameSet.mem table_name ->
-        (new_table_name_set, imrule :: acc)
+    let pred = imrule.head_predicate in
+    match pred with
+    | ImDeltaInsert table_name
+    | ImDeltaDelete table_name ->
+        (* Leave delta pred only if it is a predicate on sources or is used from another predicate. *)
+        if TableNameSet.mem table_name sources || PredicateSet.mem pred pred_set then
+          (new_pred_set, imrule :: acc)
+        else
+          (pred_set, acc)
 
     | ImPred _ ->
-        (table_name_set, acc)
+        if pred_set |> PredicateSet.mem pred then
+          (new_pred_set, imrule :: acc)
+        else
+          (pred_set, acc)
 
-  ) imrules (TableNameSet.empty, [])
+  ) imrules (PredicateSet.empty, [])
   |> snd
 
 
@@ -783,7 +781,7 @@ let remove_duplicate_rules (rules : rule list) : rule list =
   with
   | (rules, _) -> rules
 
-let simplify (rules : rule list) : (rule list, error) result =
+let simplify (rules : rule list) (sources : source list) : (rule list, error) result =
   let open ResultMonad in
 
   (* Converts each rule to an intermediate rule (with unsatisfiable ones removed): *)
@@ -799,8 +797,14 @@ let simplify (rules : rule list) : (rule list, error) result =
   (* Removes predicates that are not defined: *)
   let imrules = imrules |> resolve_undefined_predicates in
 
+  let sources =
+    sources
+    |> List.map (fun (table_name, _) -> table_name)
+    |> TableNameSet.of_list
+  in
+
   (* Removes rules that are not used: *)
-  let imrules = imrules |> remove_unused_rules in
+  let imrules = imrules |> remove_unused_rules sources in
 
   (* Removes rules that have a contradicting body: *)
   let imrules = imrules |> List.filter (fun imrule -> not (has_contradicting_body imrule)) in

--- a/src/simplification.mli
+++ b/src/simplification.mli
@@ -3,6 +3,6 @@ open Expr
 
 type error
 
-val simplify : rule list -> (rule list, error) result
+val simplify : rule list -> source list -> (rule list, error) result
 
 val string_of_error : error -> string

--- a/test/ast2sql_operation_based_conversion_test.ml
+++ b/test/ast2sql_operation_based_conversion_test.ml
@@ -209,7 +209,8 @@ let main () =
                   Printf.printf "Error: %s\n" (Inlining.string_of_error err);
                   assert false
               | Ok rules ->
-                match Simplification.simplify rules with
+                let sources = [ "a", []; "b", []; "v", [] ] in
+                match Simplification.simplify rules sources with
                 | Error err ->
                     Printf.printf "Error: %s\n" (Simplification.string_of_error err);
                     assert false

--- a/test/simplification_test.ml
+++ b/test/simplification_test.ml
@@ -5,7 +5,7 @@ open Expr
 
 type test_case = {
   title    : string;
-  input    : rule list;
+  input    : rule list * source list;
   expected : rule list;
 }
 
@@ -16,13 +16,18 @@ type test_result =
 
 let run_test (test_case : test_case) =
   let open ResultMonad in
-  Simplification.simplify test_case.input >>= fun got ->
-  let s_got = got |> List.map string_of_rule |> String.concat "; " in
-  let s_expected = test_case.expected |> List.map string_of_rule |> String.concat "; " in
-  if String.equal s_got s_expected then
-    return Pass
-  else
-    return (Fail { expected = s_expected; got = s_got })
+  let rules, sources = test_case.input in
+  match Inlining.sort_rules rules with
+  | Error err ->
+      return (Fail { expected = "no error when sorting rules."; got = Inlining.string_of_error err })
+  | Ok rules ->
+    Simplification.simplify rules sources >>= fun got ->
+    let s_got = got |> List.map string_of_rule |> String.concat "; " in
+    let s_expected = test_case.expected |> List.map string_of_rule |> String.concat "; " in
+    if String.equal s_got s_expected then
+      return Pass
+    else
+      return (Fail { expected = s_expected; got = s_got })
 
 
 (* Runs all the test cases in the given list, prints every result,
@@ -56,7 +61,7 @@ let main () =
   run_tests [
     {
       title    = "empty";
-      input    = [];
+      input    = [], [];
       expected = [];
     };
     {
@@ -76,7 +81,8 @@ let main () =
           Rel (Pred ("tracks", [ track; date; rating; album ]));
           Equat (Equation ("=", Var rating, Const (Int 1)));
         ]);
-      ];
+      ],
+      [ "tracks", [] ];
       expected = [
         (* (1) simplified:
           -tracks(TRACK, DATE, RATING, ALBUM) :-
@@ -111,7 +117,8 @@ let main () =
           Equat (Equation ("=", Var rating, Const (Int 1)));
           Not (Pred ("tracks", [ NamedVar "V31"; NamedVar "V32"; NamedVar "V33"; album ]));
         ]);
-      ];
+      ],
+      [ "tracks", [] ];
       expected = [];
     };
     {
@@ -131,7 +138,8 @@ let main () =
           Rel (Pred ("tracks", [ NamedVar "V6853"; NamedVar "V6854"; NamedVar "V6855"; album ]));
           Equat (Equation ("=", Var (NamedVar "V6855"), Const (Int 1)));
         ]);
-      ];
+      ],
+      [ "albums", [] ];
       expected = [
         (* (7) simplified:
           -albums(ALBUM, QUANTITY) :-
@@ -164,7 +172,8 @@ let main () =
           Equat (Equation ("=", Var (NamedVar "V6849"), Const (Int 1)));
           Noneq (Equation ("=", Var rating, Const (Int 1)));
         ]);
-      ];
+      ],
+      [ "albums", [] ];
       expected = [
         (* (32) simplified:
           -albums(ALBUM, QUANTITY) :-
@@ -199,7 +208,8 @@ let main () =
           Equat (Equation ("=", (Var (NamedVar "E")), (Const (String "Joe"))));
           Not (Pred ("eed", [NamedVar "E"; NamedVar "D"]));
         ]);
-      ];
+      ],
+      [ "eed", []; "ed", [] ];
       expected = [
         (* Boolean body simplified:
           +eed(E, D) :- ed(E, D) , not eed(E, D) , E = 'Joe'.
@@ -246,19 +256,20 @@ let main () =
         (Pred ("h", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
         (Pred ("g", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
         (Pred ("f", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
-      ];
+      ],
+      [ "f", []; "g", []; "a", []; "b", []; "c", []; "d", [] ];
       expected = [
-        (Deltadelete ("d", [NamedVar "X"]), [ Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 42)))) ]);
-        (Deltadelete ("b", [NamedVar "X"]), [
-          Not (Pred ("n", [NamedVar "X"])); Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 42))))
-        ]);
-        (Deltainsert ("a", [NamedVar "X"]), [
-          Rel (Pred ("n", [NamedVar "X"])); Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 42))))
-        ]);
         (Deltadelete ("g", [NamedVar "X"]), [Rel (Pred ("g", [NamedVar "X"]))]);
         (Deltainsert ("f", [NamedVar "X"]), [Rel (Pred ("f", [NamedVar "X"]))]);
         (Pred ("g", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
         (Pred ("f", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
+        (Deltainsert ("a", [NamedVar "X"]), [
+          Rel (Pred ("n", [NamedVar "X"])); Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 42))))
+        ]);
+        (Deltadelete ("d", [NamedVar "X"]), [ Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 42)))) ]);
+        (Deltadelete ("b", [NamedVar "X"]), [
+          Not (Pred ("n", [NamedVar "X"])); Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 42))))
+        ]);
       ];
     };
     {
@@ -297,18 +308,19 @@ let main () =
             Equat (Equation ("<>", (Var (NamedVar "GV1")), (Const (Int 4))))
           ]);
           (Pred ("v", [NamedVar "A"]), [Rel (Pred ("s", [NamedVar "A"; NamedVar "B"]))]);
-      ];
+      ],
+      [ "v", []; "s", [] ];
       expected = [
-        (Deltainsert ("s", [NamedVar "A"; NamedVar "B"]), [
-          Rel (Deltainsert ("v", [NamedVar "A"]));
-          Not (Deltadelete ("s", [AnonVar; NamedVar "B"]));
-          Not (Pred ("s", [NamedVar "A"; AnonVar]));
-        ]);
         (Deltainsert ("s", [NamedVar "A"; NamedVar "B"]), [
           Rel (Deltainsert ("v", [NamedVar "A"]));
           Not (Deltadelete ("s", [AnonVar; AnonVar]));
           Not (Pred ("s", [NamedVar "A"; AnonVar]));
           Equat (Equation ("=", (Var (NamedVar "B")), (Const (Int (-1)))))
+        ]);
+        (Deltainsert ("s", [NamedVar "A"; NamedVar "B"]), [
+          Rel (Deltainsert ("v", [NamedVar "A"]));
+          Not (Deltadelete ("s", [AnonVar; NamedVar "B"]));
+          Not (Pred ("s", [NamedVar "A"; AnonVar]));
         ]);
         (Deltadelete ("s", [NamedVar "A"; NamedVar "B"]), [
          Rel (Deltadelete ("v", [NamedVar "A"]));
@@ -323,6 +335,213 @@ let main () =
           Equat (Equation ("=", (Var (NamedVar "GV1")), (Const (Int 1))));
         ]);
         (Pred ("v", [NamedVar "A"]), [Rel (Pred ("s", [NamedVar "A"; AnonVar]))]);
+      ]
+    };
+    {
+      title = "removing delta preds that are not assigned to any sources";
+      input = [
+        (*
+        source ps('A':int, 'B':int).
+        view pv('A':int).
+        -ps(A, B) :- ps(A, B) , ps(A, GENV9) , A = 1 , A <> 4.
+        -pv(GENV1) :- ps(GENV1, GENV7) , GENV1 = 1 , GENV1 <> 4.
+        +ps(A, B) :- A = 4 , ps(GENV10, GENV11) , GENV10 = 1 , GENV10 <> 4 , not ps(A, GENV1) , ps(GENV2, B) , ps(GENV2, GENV12) , GENV2 = 1 , GENV2 <> 4.
+        +ps(A, B) :- A = 4 , ps(GENV13, GENV14) , GENV13 = 1 , GENV13 <> 4 , not ps(A, GENV3) , not -ps(GENV4, GENV5) , B = -100.
+        +pv(GENV1) :- GENV1 = 4 , ps(GENV1_2, GENV8) , GENV1_2 = 1 , GENV1_2 <> 4.
+        pv(A) :- ps(A, GENV6).
+        *)
+        (Pred ("pv", [NamedVar "A"]), [Rel (Pred ("ps", [NamedVar "A"; NamedVar "GENV6"]))]);
+        (* +pv(GENV1) :- GENV1 = 4 , ps(GENV1_2, GENV8) , GENV1_2 = 1 , GENV1_2 <> 4. *)
+        (Deltainsert ("pv", [NamedVar "GENV1"]), [
+          (Equat (Equation ("=", Var (NamedVar "GENV1"), Const (Int 4))));
+          (Rel (Pred ("ps", [NamedVar "GENV1_2"; NamedVar "GENV8"])));
+          (Equat (Equation ("=", Var (NamedVar "GENV1_2"), Const (Int 1))));
+          (Equat (Equation ("<>", Var (NamedVar "GENV1_2"), Const (Int 4))));
+        ]);
+        (* +ps(A, B) :- A = 4 , ps(GENV13, GENV14) , GENV13 = 1 , GENV13 <> 4 , not ps(A, GENV3) , not -ps(GENV4, GENV5) , B = -100. *)
+        (Deltainsert ("ps", [NamedVar "A"; NamedVar "B"]), [
+          (Equat (Equation ("=", Var (NamedVar "A"), Const (Int 4))));
+          (Rel (Pred ("ps", [NamedVar "GENV13"; NamedVar "GENV14"])));
+          (Equat (Equation ("=", Var (NamedVar "GENV13"), Const (Int 1))));
+          (Equat (Equation ("<>", Var (NamedVar "GENV13"), Const (Int 4))));
+          (Not (Pred ("ps", [NamedVar "A"; NamedVar "GENV3"])));
+          (Not (Deltadelete ("ps", [NamedVar "GENV4"; NamedVar "GENV5"])));
+          (Equat (Equation ("=", Var (NamedVar "B"), Const (Int (-100)))));
+        ]);
+        (* +ps(A, B) :- A = 4 , ps(GENV10, GENV11) , GENV10 = 1 , GENV10 <> 4 , not ps(A, GENV1) , ps(GENV2, B) , ps(GENV2, GENV12) , GENV2 = 1 , GENV2 <> 4. *)
+        (Deltainsert ("ps", [NamedVar "A"; NamedVar "B"]), [
+          (Equat (Equation ("=", Var (NamedVar "A"), Const (Int 4))));
+          (Rel (Pred ("ps", [NamedVar "GENV10"; NamedVar "GENV11"])));
+          (Equat (Equation ("=", Var (NamedVar "GENV10"), Const (Int 1))));
+          (Equat (Equation ("<>", Var (NamedVar "GENV10"), Const (Int 4))));
+          (Not (Pred ("ps", [NamedVar "A"; NamedVar "GENV1"])));
+          (Rel (Pred ("ps", [NamedVar "GENV2"; NamedVar "B"])));
+          (Rel (Pred ("ps", [NamedVar "GENV2"; NamedVar "GENV12"])));
+          (Equat (Equation ("=", Var (NamedVar "GENV2"), Const (Int 1))));
+          (Equat (Equation ("<>", Var (NamedVar "GENV2"), Const (Int 4))));
+        ]);
+        (* -pv(GENV1) :- ps(GENV1, GENV7) , GENV1 = 1 , GENV1 <> 4. *)
+        (Deltadelete ("pv", [NamedVar "GENV1"]), [
+          (Rel (Pred ("ps", [NamedVar "GENV1"; NamedVar "GENV7"])));
+          (Equat (Equation ("=", Var (NamedVar "GENV1"), Const (Int 1))));
+          (Equat (Equation ("<>", Var (NamedVar "GENV1"), Const (Int 4))));
+        ]);
+        (* -ps(A, B) :- ps(A, B) , ps(A, GENV9) , A = 1 , A <> 4. *)
+        (Deltadelete ("ps", [NamedVar "A"; NamedVar "B"]), [
+          (Rel (Pred ("ps", [NamedVar "A"; NamedVar "B"])));
+          (Rel (Pred ("ps", [NamedVar "A"; NamedVar "GENV9"])));
+          (Equat (Equation ("=", Var (NamedVar "A"), Const (Int 1))));
+          (Equat (Equation ("<>", Var (NamedVar "A"), Const (Int 4))));
+        ]);
+      ],
+      ["ps", []];
+      expected = [
+        (*
+        +ps(A, B) :- ps(GENV13, _) , not -ps(_, _) , not ps(A, _) , A = 4 , B = -100 , GENV13 = 1.
+        +ps(A, B) :- ps(GENV10, _) , ps(GENV2, B) , not ps(A, _) , A = 4 , GENV10 = 1 , GENV2 = 1.
+        -ps(A, B) :- ps(A, B) , A = 1.
+        *)
+        (Deltainsert ("ps", [NamedVar "A"; NamedVar "B"]), [
+          (Rel (Pred ("ps", [NamedVar "GENV13"; AnonVar])));
+          (Not (Deltadelete ("ps", [AnonVar; AnonVar])));
+          (Not (Pred ("ps", [NamedVar "A"; AnonVar])));
+          (Equat (Equation ("=", Var (NamedVar "A"), Const (Int 4))));
+          (Equat (Equation ("=", Var (NamedVar "B"), Const (Int (-100)))));
+          (Equat (Equation ("=", Var (NamedVar "GENV13"), Const (Int 1))));
+        ]);
+        (Deltainsert ("ps", [NamedVar "A"; NamedVar "B"]), [
+          (Rel (Pred ("ps", [NamedVar "GENV10"; AnonVar])));
+          (Rel (Pred ("ps", [NamedVar "GENV2"; NamedVar "B"])));
+          (Not (Pred ("ps", [NamedVar "A"; AnonVar])));
+          (Equat (Equation ("=", Var (NamedVar "A"), Const (Int 4))));
+          (Equat (Equation ("=", Var (NamedVar "GENV10"), Const (Int 1))));
+          (Equat (Equation ("=", Var (NamedVar "GENV2"), Const (Int 1))));
+        ]);
+        (Deltadelete ("ps", [NamedVar "A"; NamedVar "B"]), [
+          (Rel (Pred ("ps", [NamedVar "A"; NamedVar "B"])));
+          (Equat (Equation ("=", Var (NamedVar "A"), Const (Int 1))));
+        ]);
+      ]
+    };
+    {
+      title = "leave used delta preds that are not assigned to any sources";
+      input = [
+        (*
+        source b('B':int, 'C':int).
+        source a('A':int, 'B':int).
+        view v('A':int, 'B':int, 'C':int).
+        -a(A, B) :- a(A, B) , not __updated__v(A, B, GENV1).
+        -b(B, C) :- b(B, C) , a(GENV2, B) , b(B, GENV3) , not -v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C).
+        -b(B, C) :- b(B, C) , +v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C).
+        -v(GENV1, GENV2, GENV3) :- a(GENV1, GENV2) , b(GENV2, GENV3) , GENV2 = 30 , GENV2 <> 60.
+        +a(A, B) :- a(A, B) , b(B, GENV5) , not -v(A, B, GENV5) , not a(A, B).
+        +a(A, B) :- +v(A, B, GENV5) , not a(A, B).
+        +b(B, C) :- a(GENV6, B) , b(B, C) , not -v(GENV6, B, C) , not b(B, C).
+        +b(B, C) :- +v(GENV6, B, C) , not b(B, C).
+        __updated__v(A, B, C) :- a(A, B) , b(B, C) , not -v(A, B, C).
+        __updated__v(A, B, C) :- +v(A, B, C).
+        v(A, B, C) :- a(A, B) , b(B, C).
+        *)
+        (Pred ("v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("a", [NamedVar "A"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* __updated__v(A, B, C) :- +v(A, B, C). *)
+        (Pred ("__updated__v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]), [
+          Rel (Deltainsert ("v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* __updated__v(A, B, C) :- a(A, B) , b(B, C) , not -v(A, B, C). *)
+        (Pred ("__updated__v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("a", [NamedVar "A"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]));
+          Not (Deltadelete ("v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* +b(B, C) :- +v(GENV6, B, C) , not b(B, C). *)
+        (Deltainsert ("b", [NamedVar "B"; NamedVar "C"]), [
+          Rel (Deltainsert ("v", [NamedVar "GENV6"; NamedVar "B"; NamedVar "C"]));
+          Not (Pred ("b", [NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* +b(B, C) :- a(GENV6, B) , b(B, C) , not -v(GENV6, B, C) , not b(B, C). *)
+        (Deltainsert ("b", [NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("a", [NamedVar "GENV6"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]));
+          Not (Deltadelete ("v", [NamedVar "GENV6"; NamedVar "B"; NamedVar "C"]));
+          Not (Pred ("b", [NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* +a(A, B) :- +v(A, B, GENV5) , not a(A, B). *)
+        (Deltainsert ("a", [NamedVar "A"; NamedVar "B"]), [
+          Rel (Deltainsert ("v", [NamedVar "A"; NamedVar "B"; NamedVar "GENV5"]));
+          Not (Pred ("a", [NamedVar "A"; NamedVar "B"]))
+        ]);
+        (* +a(A, B) :- a(A, B) , b(B, GENV5) , not -v(A, B, GENV5) , not a(A, B). *)
+        (Deltainsert ("a", [NamedVar "A"; NamedVar "B"]), [
+          Rel (Pred ("a", [NamedVar "A"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "GENV5"]));
+          Not (Deltadelete ("v", [NamedVar "A"; NamedVar "B"; NamedVar "GENV5"]));
+          Not (Pred ("a", [NamedVar "A"; NamedVar "B"]))
+        ]);
+        (* -v(GENV1, GENV2, GENV3) :- a(GENV1, GENV2) , b(GENV2, GENV3) , GENV2 = 30 , GENV2 <> 60. *)
+        (Deltadelete ("v", [NamedVar "GENV1"; NamedVar "GENV2"; NamedVar "GENV3"]), [
+          Rel (Pred ("a", [NamedVar "GENV1"; NamedVar "GENV2"]));
+          Rel (Pred ("b", [NamedVar "GENV2"; NamedVar "GENV3"]));
+          Equat (Equation ("=", Var (NamedVar "GENV2"), Const (Int 30)));
+          Equat (Equation ("<>", Var (NamedVar "GENV2"), Const (Int 60)))
+        ]);
+        (* -b(B, C) :- b(B, C) , +v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C). *)
+        (Deltadelete ("b", [NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]));
+          Rel (Deltainsert ("v", [NamedVar "GENV2"; NamedVar "B"; NamedVar "GENV3"]));
+          Not (Pred ("__updated__v", [NamedVar "GENV4"; NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* -b(B, C) :- b(B, C) , a(GENV2, B) , b(B, GENV3) , not -v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C). *)
+        (Deltadelete ("b", [NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]));
+          Rel (Pred ("a", [NamedVar "GENV2"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "GENV3"]));
+          Not (Deltadelete ("v", [NamedVar "GENV2"; NamedVar "B"; NamedVar "GENV3"]));
+          Not (Pred ("__updated__v", [NamedVar "GENV4"; NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* -a(A, B) :- a(A, B) , not __updated__v(A, B, GENV1). *)
+        (Deltadelete ("a", [NamedVar "A"; NamedVar "B"]), [
+          Rel (Pred ("a", [NamedVar "A"; NamedVar "B"]));
+          Not (Pred ("__updated__v", [NamedVar "A"; NamedVar "B"; NamedVar "GENV1"]))
+        ]);
+      ],
+      ["a", []; "b", []];
+      expected = [
+        (*
+        source a('A':int, 'B':int).
+        source b('B':int, 'C':int).
+        view v('A':int, 'B':int, 'C':int).
+        -a(A, B) :- a(A, B) , not __updated__v(A, B, _).
+        -b(B, C) :- a(GENV2, B) , b(B, C) , b(B, GENV3) , not -v(GENV2, B, GENV3) , not __updated__v(_, B, C).
+        __updated__v(A, B, C) :- a(A, B) , b(B, C) , not -v(A, B, C).
+        -v(GENV1, GENV2, GENV3) :- a(GENV1, GENV2) , b(GENV2, GENV3) , GENV2 = 30.
+        *)
+        (Deltadelete ("a", [NamedVar "A"; NamedVar "B"]), [
+          Rel (Pred ("a", [NamedVar "A"; NamedVar "B"]));
+          Not (Pred ("__updated__v", [NamedVar "A"; NamedVar "B"; AnonVar]))
+        ]);
+        (* -b(B, C) :- a(GENV2, B) , b(B, C) , b(B, GENV3) , not -v(GENV2, B, GENV3) , not __updated__v(_, B, C). *)
+        (Deltadelete ("b", [NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("a", [NamedVar "GENV2"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "GENV3"]));
+          Not (Deltadelete ("v", [NamedVar "GENV2"; NamedVar "B"; NamedVar "GENV3"]));
+          Not (Pred ("__updated__v", [AnonVar; NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* __updated__v(A, B, C) :- a(A, B) , b(B, C) , not -v(A, B, C). *)
+        (Pred ("__updated__v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]), [
+          Rel (Pred ("a", [NamedVar "A"; NamedVar "B"]));
+          Rel (Pred ("b", [NamedVar "B"; NamedVar "C"]));
+          Not (Deltadelete ("v", [NamedVar "A"; NamedVar "B"; NamedVar "C"]))
+        ]);
+        (* -v(GENV1, GENV2, GENV3) :- a(GENV1, GENV2) , b(GENV2, GENV3) , GENV2 = 30. *)
+        (Deltadelete ("v", [NamedVar "GENV1"; NamedVar "GENV2"; NamedVar "GENV3"]), [
+          Rel (Pred ("a", [NamedVar "GENV1"; NamedVar "GENV2"]));
+          Rel (Pred ("b", [NamedVar "GENV2"; NamedVar "GENV3"]));
+          Equat (Equation ("=", Var (NamedVar "GENV2"), Const (Int 30)))
+        ]);
       ]
     }
   ]


### PR DESCRIPTION
関連 issue: https://github.com/proof-ninja/BIRDS/issues/45

## 概要

以前の実装では、 simplification の際にΔ述語は全て残すようにしていたが、この修正で、 sources のテーブル名と異なり、他の述語でも使われていないΔ述語は削除されるようになった。

## 確認方法

```
❯ dune exec bin/simplification.exe -- examples/simplification3_1.dl
source ps('A':int, 'B':int).           
view pv('A':int).
+ps(A, B) :- ps(GENV13, _) , not -ps(_, _) , not ps(A, _) , A = 4 , B = -100 , GENV13 = 1.
+ps(A, B) :- ps(GENV10, _) , ps(GENV2, B) , not ps(A, _) , A = 4 , GENV10 = 1 , GENV2 = 1.
-ps(A, B) :- ps(A, B) , A = 1.
```