### PR TITLE
simplification コマンドに `--prepare` オプションを追加した

### DIFF
--- a/bin/dl2u.ml
+++ b/bin/dl2u.ml
@@ -11,7 +11,7 @@ let sort rules =
 
 let simplify rules sources =
   let open Result in
-  match Simplification.simplify rules sources with
+  match Simplification.simplify rules None sources with
   | Error err ->
       error @@ Simplification.string_of_error err
   | Result.Ok rules ->

--- a/bin/simplification.ml
+++ b/bin/simplification.ml
@@ -1,5 +1,11 @@
 open Birds
 
+let build_view ast =
+  if Array.length Sys.argv >= 3 && Sys.argv.(2) = "--prepare" then
+    ast.Expr.view
+  else
+    None
+
 let _ =
   if Array.length Sys.argv < 2 then
     print_endline "Invalid arguments. File name must be passed."
@@ -10,11 +16,12 @@ let _ =
     let ast = Parser.main Lexer.token lexbuf in
     let rules = ast.rules in
     let sources = ast.sources in
+    let view = build_view ast in
     match Inlining.sort_rules rules with
     | Result.Error err ->
       print_endline @@ Inlining.string_of_error err
     | Result.Ok rules ->
-      match Simplification.simplify rules sources with
+      match Simplification.simplify rules view sources with
       | Result.Error err ->
         print_endline @@ Simplification.string_of_error err
       | Result.Ok rules ->

--- a/examples/simplification_prepare1.dl
+++ b/examples/simplification_prepare1.dl
@@ -1,0 +1,5 @@
+source x('A':int).
+view v('A':int).
+
++x(A) :- x(A), v(A), A <> 42.
+-x(A) :- +x(A), -v(A).

--- a/examples/simplification_prepare2.dl
+++ b/examples/simplification_prepare2.dl
@@ -1,0 +1,5 @@
+source x('A':int).
+view v('A':int).
+
++x(A) :- x(A), v(A), A <> 42.
+-x(A) :- +x(A), +v(A).

--- a/examples/simplification_prepare3.dl
+++ b/examples/simplification_prepare3.dl
@@ -1,0 +1,13 @@
+source b('B':int, 'C':int).
+source a('A':int, 'B':int).
+view v('A':int, 'B':int, 'C':int).
+-a(A, B) :- a(A, B) , not __updated__v(A, B, GENV1).
+-b(B, C) :- b(B, C) , a(GENV2, B) , b(B, GENV3) , not -v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C).
+-b(B, C) :- b(B, C) , +v(GENV2, B, GENV3) , not __updated__v(GENV4, B, C).
++a(A, B) :- a(A, B) , b(B, GENV5) , not -v(A, B, GENV5) , not a(A, B).
++a(A, B) :- +v(A, B, GENV5) , not a(A, B).
++b(B, C) :- a(GENV6, B) , b(B, C) , not -v(GENV6, B, C) , not b(B, C).
++b(B, C) :- +v(GENV6, B, C) , not b(B, C).
+__updated__v(A, B, C) :- a(A, B) , b(B, C) , not -v(A, B, C).
+__updated__v(A, B, C) :- +v(A, B, C).
+v(A, B, C) :- a(A, B) , b(B, C).

--- a/examples/simplification_prepare4.dl
+++ b/examples/simplification_prepare4.dl
@@ -1,0 +1,10 @@
+source projs('A':int, 'B':string).
+view projv('A':int).
+-projs(A, B) :- projs(A, B) , -projv(A).
++projs(A, B) :- projs(A, GENV7) , not -projv(A) , not projs(A, GENV1) , not -projs(GENV2, GENV3) , B = 'a'.
++projs(A, B) :- projs(A, GENV8) , not -projv(A) , not projs(A, GENV4) , projs(GENV5, B) , -projv(GENV5).
++projs(A, B) :- +projv(A) , not projs(A, GENV1) , not -projs(GENV2, GENV3) , B = 'a'.
++projs(A, B) :- +projv(A) , not projs(A, GENV4) , projs(GENV5, B) , -projv(GENV5).
+__updated__projv(A) :- projs(A, GENV6) , not -projv(A).
+__updated__projv(A) :- +projv(A).
+projv(A) :- projs(A, B).

--- a/examples/simplification_prepare5.dl
+++ b/examples/simplification_prepare5.dl
@@ -1,0 +1,13 @@
+source uniona('NAME':string).
+source unionb('NAME':string).
+source uniono('NAME':string, 'TP':string).
+view unionview('NAME':string, 'TP':string).
+-uniona(N) :- uniona(N) , -unionview(N, T) , T = 'A'.
+-unionb(N) :- unionb(N) , -unionview(N, T) , T = 'B'.
+-uniono(N, T) :- uniono(N, T) , -unionview(N, T).
++uniona(N) :- +unionview(N, T) , not uniona(N) , T = 'A' , not uniono(N, T).
++unionb(N) :- +unionview(N, T) , not unionb(N) , T = 'B' , not uniono(N, T).
++uniono(N, T) :- +unionview(N, T) , not uniono(N, T) , not T = 'A' , not T = 'B'.
+unionview(N, T) :- uniona(N) , T = 'A'.
+unionview(N, T) :- unionb(N) , T = 'B'.
+unionview(N, T) :- uniono(N, T).

--- a/src/simplification.mli
+++ b/src/simplification.mli
@@ -3,6 +3,6 @@ open Expr
 
 type error
 
-val simplify : rule list -> source list -> (rule list, error) result
+val simplify : rule list -> view option -> source list -> (rule list, error) result
 
 val string_of_error : error -> string

--- a/test/ast2sql_operation_based_conversion_test.ml
+++ b/test/ast2sql_operation_based_conversion_test.ml
@@ -210,7 +210,7 @@ let main () =
                   assert false
               | Ok rules ->
                 let sources = [ "a", []; "b", []; "v", [] ] in
-                match Simplification.simplify rules sources with
+                match Simplification.simplify rules None sources with
                 | Error err ->
                     Printf.printf "Error: %s\n" (Simplification.string_of_error err);
                     assert false

--- a/test/simplification_test.ml
+++ b/test/simplification_test.ml
@@ -5,7 +5,7 @@ open Expr
 
 type test_case = {
   title    : string;
-  input    : rule list * source list;
+  input    : rule list * view option * source list;
   expected : rule list;
 }
 
@@ -16,12 +16,12 @@ type test_result =
 
 let run_test (test_case : test_case) =
   let open ResultMonad in
-  let rules, sources = test_case.input in
+  let rules, view, sources = test_case.input in
   match Inlining.sort_rules rules with
   | Error err ->
       return (Fail { expected = "no error when sorting rules."; got = Inlining.string_of_error err })
   | Ok rules ->
-    Simplification.simplify rules sources >>= fun got ->
+    Simplification.simplify rules view sources >>= fun got ->
     let s_got = got |> List.map string_of_rule |> String.concat "; " in
     let s_expected = test_case.expected |> List.map string_of_rule |> String.concat "; " in
     if String.equal s_got s_expected then
@@ -61,7 +61,7 @@ let main () =
   run_tests [
     {
       title    = "empty";
-      input    = [], [];
+      input    = [], None, [];
       expected = [];
     };
     {
@@ -82,6 +82,7 @@ let main () =
           Equat (Equation ("=", Var rating, Const (Int 1)));
         ]);
       ],
+      None,
       [ "tracks", [] ];
       expected = [
         (* (1) simplified:
@@ -118,6 +119,7 @@ let main () =
           Not (Pred ("tracks", [ NamedVar "V31"; NamedVar "V32"; NamedVar "V33"; album ]));
         ]);
       ],
+      None,
       [ "tracks", [] ];
       expected = [];
     };
@@ -139,6 +141,7 @@ let main () =
           Equat (Equation ("=", Var (NamedVar "V6855"), Const (Int 1)));
         ]);
       ],
+      None,
       [ "albums", [] ];
       expected = [
         (* (7) simplified:
@@ -173,6 +176,7 @@ let main () =
           Noneq (Equation ("=", Var rating, Const (Int 1)));
         ]);
       ],
+      None,
       [ "albums", [] ];
       expected = [
         (* (32) simplified:
@@ -209,6 +213,7 @@ let main () =
           Not (Pred ("eed", [NamedVar "E"; NamedVar "D"]));
         ]);
       ],
+      None,
       [ "eed", []; "ed", [] ];
       expected = [
         (* Boolean body simplified:
@@ -257,6 +262,7 @@ let main () =
         (Pred ("g", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
         (Pred ("f", [NamedVar "X"]), [Equat (Equation ("=", (Var (NamedVar "X")), (Const (Int 1))))]);
       ],
+      None,
       [ "f", []; "g", []; "a", []; "b", []; "c", []; "d", [] ];
       expected = [
         (Deltadelete ("g", [NamedVar "X"]), [Rel (Pred ("g", [NamedVar "X"]))]);
@@ -309,6 +315,7 @@ let main () =
           ]);
           (Pred ("v", [NamedVar "A"]), [Rel (Pred ("s", [NamedVar "A"; NamedVar "B"]))]);
       ],
+      None,
       [ "v", []; "s", [] ];
       expected = [
         (Deltainsert ("s", [NamedVar "A"; NamedVar "B"]), [
@@ -394,6 +401,7 @@ let main () =
           (Equat (Equation ("<>", Var (NamedVar "A"), Const (Int 4))));
         ]);
       ],
+      None,
       ["ps", []];
       expected = [
         (*
@@ -507,6 +515,7 @@ let main () =
           Not (Pred ("__updated__v", [NamedVar "A"; NamedVar "B"; NamedVar "GENV1"]))
         ]);
       ],
+      None,
       ["a", []; "b", []];
       expected = [
         (*


### PR DESCRIPTION
修正内容: https://hackmd.io/n7zyyweESjap8K8Qxk3kfA

## 概要

simplification コマンドに `--prepare` オプションを付けることで、 view がある場合に、その view と同名のΔ述語が存在しているかのように処理される。
詳しくはサンプルコードを見てみてください。

## サンプルコード

```dl
source x('A':int).
view v('A':int).

+x(A) :- x(A), v(A), A <> 42.
-x(A) :- +x(A), -v(A).
```

```
❯ dune exec bin/simplification.exe -- examples/simplification_prepare1.dl
source x('A':int).                     
view v('A':int).
+x(A) :- v(A) , x(A) , not A = 42.

❯ dune exec bin/simplification.exe -- examples/simplification_prepare1.dl --prepare
source x('A':int).                     
view v('A':int).
-x(A) :- -v(A) , +x(A).
+x(A) :- v(A) , x(A) , not A = 42.
```

`-v(A)`  は存在しないため、 simplification コマンドを使うと `-x(A) :- +x(A), -v(A).` は偽とみなされて消されてしまう。
しかし、 `--prepare` オプションを付けると、 view である `v` から `+v(A)` と `-v(A)` が存在するとみなされるので、 `-x(A)` も残る。

delta insert の場合も同様。

```
source x('A':int).
view v('A':int).

+x(A) :- x(A), v(A), A <> 42.
-x(A) :- +x(A), +v(A).
```

```
❯ dune exec bin/simplification.exe -- examples/simplification_prepare2.dl 
source x('A':int).                     
view v('A':int).
+x(A) :- v(A) , x(A) , not A = 42.

❯ dune exec bin/simplification.exe -- examples/simplification_prepare2.dl --prepare
source x('A':int).                     
view v('A':int).
-x(A) :- +v(A) , +x(A).
+x(A) :- v(A) , x(A) , not A = 42.
```