### PR TITLE
#46 2-1の修正: ast2sqlでソースのカラム名を伝搬させず述語のカラム名をそのまま使うようにした

### DIFF
--- a/examples/dl2u_error.dl
+++ b/examples/dl2u_error.dl
@@ -1,0 +1,5 @@
+source a('A':int, 'B':int).
+source b('B':int, 'C':int).
+view v('A':int, 'B':int, 'C':int).
+-a(A, B) :- a(A, B) , tmp(A, B, C).
+tmp(A, B, C) :- a(A, G) , b(G, C) , B = 60 , G = 30.

--- a/examples/dl2u_name.dl
+++ b/examples/dl2u_name.dl
@@ -1,0 +1,4 @@
+source a('A':int, 'B':int).
+view v('A':int, 'B':int, 'C':int).
+-a(A, B) :- f(B, A).
+f(C, D) :- a(D, C).

--- a/src/ast2sql.ml
+++ b/src/ast2sql.ml
@@ -2320,9 +2320,9 @@ let update_table_env (head : rterm) (body : term list) (table_env : table_enviro
   if TableEnv.mem table table_env then
     return table_env
   else
-    args |> List.rev |> foldM (fun colmns arg ->
+    args |> List.rev |> foldM (fun columns arg ->
       match arg with
-      | NamedVar x -> return (x :: colmns)
+      | NamedVar x -> return (x :: columns)
       | _          -> err @@ InvalidArgInHead { var = arg; error_detail = InRule (head, body) }
     ) [] >>= fun columns ->
     return @@ TableEnv.add table columns table_env

--- a/src/ast2sql.ml
+++ b/src/ast2sql.ml
@@ -2309,9 +2309,6 @@ type grouping_state =
   | NoneState
 
 
-module ArgMap = Map.Make(String)
-
-
 let update_table_env (head : rterm) (body : term list) (table_env : table_environment) : (table_environment, error) result =
   let open ResultMonad in
   let table, args =

--- a/test/ast2sql_operation_based_conversion_test.ml
+++ b/test/ast2sql_operation_based_conversion_test.ml
@@ -227,14 +227,14 @@ let main () =
             primary_keys = [];
           };
         expected = String.concat " " [
-          "CREATE TEMPORARY TABLE v AS SELECT a_0.AA AS AA, a_0.BB AS BB, b_1.CC AS CC FROM a AS a_0, b AS b_1 WHERE b_1.BB = a_0.BB;";
-          "CREATE TEMPORARY TABLE temp0 AS SELECT v_0.AA AS AA, v_0.BB AS BB, 3 AS CC FROM v AS v_0 WHERE v_0.CC = 3 AND v_0.AA <> 4;";
-          "CREATE TEMPORARY TABLE temp1 AS SELECT 4 AS AA, temp0.BB AS BB, temp0.CC AS CC FROM temp0 AS temp0;";
-          "CREATE TEMPORARY TABLE uv AS SELECT v_0.AA AS AA, v_0.BB AS BB, v_0.CC AS CC FROM v AS v_0 WHERE NOT EXISTS ( SELECT * FROM temp0 AS t WHERE t.AA = v_0.AA AND t.BB = v_0.BB AND t.CC = v_0.CC ) UNION SELECT temp1.AA AS AA, temp1.BB AS BB, temp1.CC AS CC FROM temp1 AS temp1;";
-          "CREATE TEMPORARY TABLE temp2 AS SELECT uv_0.BB AS BB, uv_0.CC AS CC FROM uv AS uv_0 WHERE NOT EXISTS ( SELECT * FROM b AS t WHERE t.BB = uv_0.BB AND t.CC = uv_0.CC );";
-          "CREATE TEMPORARY TABLE temp3 AS SELECT uv_0.AA AS AA, uv_0.BB AS BB FROM uv AS uv_0 WHERE NOT EXISTS ( SELECT * FROM a AS t WHERE t.AA = uv_0.AA AND t.BB = uv_0.BB );";
-          "CREATE TEMPORARY TABLE temp4 AS SELECT b_0.BB AS BB, b_0.CC AS CC FROM b AS b_0, uv AS uv_1 WHERE uv_1.BB = b_0.BB AND NOT EXISTS ( SELECT * FROM uv AS t WHERE t.BB = b_0.BB AND t.CC = b_0.CC );";
-          "CREATE TEMPORARY TABLE temp5 AS SELECT a_0.AA AS AA, a_0.BB AS BB FROM a AS a_0 WHERE NOT EXISTS ( SELECT * FROM uv AS t WHERE t.AA = a_0.AA AND t.BB = a_0.BB );";
+          "CREATE TEMPORARY TABLE v AS SELECT a_0.AA AS A, a_0.BB AS B, b_1.CC AS C FROM a AS a_0, b AS b_1 WHERE b_1.BB = a_0.BB;";
+          "CREATE TEMPORARY TABLE temp0 AS SELECT v_0.A AS A, v_0.B AS B, 3 AS C FROM v AS v_0 WHERE v_0.C = 3 AND v_0.A <> 4;";
+          "CREATE TEMPORARY TABLE temp1 AS SELECT 4 AS A, temp0.B AS B, temp0.C AS C FROM temp0 AS temp0;";
+          "CREATE TEMPORARY TABLE uv AS SELECT v_0.A AS A, v_0.B AS B, v_0.C AS C FROM v AS v_0 WHERE NOT EXISTS ( SELECT * FROM temp0 AS t WHERE t.A = v_0.A AND t.B = v_0.B AND t.C = v_0.C ) UNION SELECT temp1.A AS A, temp1.B AS B, temp1.C AS C FROM temp1 AS temp1;";
+          "CREATE TEMPORARY TABLE temp2 AS SELECT uv_0.B AS BB, uv_0.C AS CC FROM uv AS uv_0 WHERE NOT EXISTS ( SELECT * FROM b AS t WHERE t.BB = uv_0.B AND t.CC = uv_0.C );";
+          "CREATE TEMPORARY TABLE temp3 AS SELECT uv_0.A AS AA, uv_0.B AS BB FROM uv AS uv_0 WHERE NOT EXISTS ( SELECT * FROM a AS t WHERE t.AA = uv_0.A AND t.BB = uv_0.B );";
+          "CREATE TEMPORARY TABLE temp4 AS SELECT b_0.BB AS BB, b_0.CC AS CC FROM b AS b_0, uv AS uv_1 WHERE uv_1.B = b_0.BB AND NOT EXISTS ( SELECT * FROM uv AS t WHERE t.B = b_0.BB AND t.C = b_0.CC );";
+          "CREATE TEMPORARY TABLE temp5 AS SELECT a_0.AA AS AA, a_0.BB AS BB FROM a AS a_0 WHERE NOT EXISTS ( SELECT * FROM uv AS t WHERE t.A = a_0.AA AND t.B = a_0.BB );";
           "INSERT INTO b SELECT * FROM temp2;";
           "INSERT INTO a SELECT * FROM temp3;";
           "DELETE FROM b USING temp4 WHERE b.BB = temp4.BB AND b.CC = temp4.CC;";


### PR DESCRIPTION
#46 (2-1) 同じ変数が複数の述語に現れると、エラー場合がある。の対応です

## 方針

これまでast2sqlはカラムのエイリアス名にソースのカラム名を伝搬させるルールになっていました。
しかしこのルールには以下の2点の考慮漏れがあり、SQLを生成できないDatalog式が多く存在しました。

1. headに出てこない変数
2. predicateに渡されていない変数

例えば `tmp(A, B, C) :- a(A, G) , b(G, C) , B = 60 , G = 30.` の場合、変数 `G` が(1)、変数 `B` が(2)に該当します。

そこで、このルールを削除し、素直に述語のカラム名をそのまま使用するように変更します。

## 入出力例1: #46 (2-1) のエラー例

### 入力 (dl2u_error.dl)

```dl2u_error.dl
source a('A':int, 'B':int).
source b('B':int, 'C':int).
view v('A':int, 'B':int, 'C':int).
-a(A, B) :- a(A, B) , tmp(A, B, C).
tmp(A, B, C) :- a(A, G) , b(G, C) , B = 60 , G = 30.
```

### コマンド

```sh
dune exec dl2u examples/dl2u_error.dl
```

### 望ましい出力

エラーにならない

### 修正後の出力

エラーにならず以下が出力される

```sql
CREATE TEMPORARY TABLE tmp AS SELECT a_0.A AS A, 60 AS B, b_1.C AS C FROM a AS a_0, b AS b_1 WHERE a_0.B = 30 AND b_1.B = 30;
CREATE TEMPORARY TABLE temp0 AS SELECT a_0.A AS A, a_0.B AS B FROM a AS a_0, tmp AS tmp_1 WHERE tmp_1.A = a_0.A AND tmp_1.B = a_0.B;
DELETE FROM a USING temp0 WHERE a.A = temp0.A AND a.B = temp0.B;
```

## 入出力例2: エイリアス名が変わる例

### 入力

```dl2u_name.dl
source a('A':int, 'B':int).
view v('A':int, 'B':int, 'C':int).
-a(A, B) :- f(B, A).
f(C, D) :- a(D, C).
```

### コマンド

```
dune exec dl2u examples/dl2u_name.dl
```

### 修正前の出力

テンポラリテーブル `f` のエイリアス名にソース `a` の `B`, `A` が使われている。

```sql
CREATE TEMPORARY TABLE f AS SELECT a_0.B AS B, a_0.A AS A FROM a AS a_0;
CREATE TEMPORARY TABLE temp0 AS SELECT f_0.A AS A, f_0.B AS B FROM f AS f_0;
DELETE FROM a USING temp0 WHERE a.A = temp0.A AND a.B = temp0.B;
```

### 修正後の出力

テンポラリテーブル `f` のエイリアス名に述語 `f` 自体のカラム名 `C`, `D` が使われている。

```sql
CREATE TEMPORARY TABLE f AS SELECT a_0.B AS C, a_0.A AS D FROM a AS a_0;
CREATE TEMPORARY TABLE temp0 AS SELECT f_0.D AS A, f_0.C AS B FROM f AS f_0;
DELETE FROM a USING temp0 WHERE a.A = temp0.A AND a.B = temp0.B;
```
